### PR TITLE
update: modified to parse all args even if there are errors

### DIFF
--- a/parse-for.go
+++ b/parse-for.go
@@ -6,6 +6,7 @@ package cliargs
 
 import (
 	"fmt"
+	"path"
 	"reflect"
 	"strconv"
 	"strings"
@@ -140,7 +141,11 @@ func (e IllegalOptionType) Error() string {
 func ParseFor(osArgs []string, options any) (Cmd, []OptCfg, error) {
 	optCfgs, err := MakeOptCfgsFor(options)
 	if err != nil {
-		return Cmd{args: empty}, optCfgs, err
+		var cmdName string
+		if len(osArgs) > 0 {
+			cmdName = path.Base(osArgs[0])
+		}
+		return Cmd{Name: cmdName, args: empty}, optCfgs, err
 	}
 
 	cmd, err := ParseWith(osArgs, optCfgs)

--- a/parse-for_test.go
+++ b/parse-for_test.go
@@ -12,11 +12,11 @@ import (
 
 func TestParseFor_emptyOptionStoreAndNoArgs(t *testing.T) {
 	type MyOptions struct{}
-	osArgs := []string{}
+	osArgs := []string{"/path/to/app"}
 	options := MyOptions{}
 	cmd, optCfgs, err := cliargs.ParseFor(osArgs, &options)
 	assert.Nil(t, err)
-	assert.Equal(t, cmd.Name, "")
+	assert.Equal(t, cmd.Name, "app")
 	assert.Equal(t, cmd.Args(), []string{})
 	assert.Equal(t, optCfgs, []cliargs.OptCfg{})
 }
@@ -53,10 +53,10 @@ func TestParseFor_nonEmptyOptionStoreAndNoArgs(t *testing.T) {
 	}
 	options := MyOptions{}
 
-	osArgs := []string{}
+	osArgs := []string{"/path/to/app"}
 	cmd, optCfgs, err := cliargs.ParseFor(osArgs, &options)
 	assert.Nil(t, err)
-	assert.Equal(t, cmd.Name, "")
+	assert.Equal(t, cmd.Name, "app")
 	assert.Equal(t, cmd.Args(), []string{})
 	assert.Equal(t, len(optCfgs), 27)
 	assert.False(t, options.BoolVal)
@@ -148,10 +148,10 @@ func TestParseFor_dontOverwriteOptionsIfNoArgs(t *testing.T) {
 		StringArr:  []string{"ab", "cd", "efg"},
 	}
 
-	osArgs := []string{}
+	osArgs := []string{"/path/to/app"}
 	cmd, optCfgs, err := cliargs.ParseFor(osArgs, &options)
 	assert.Nil(t, err)
-	assert.Equal(t, cmd.Name, "")
+	assert.Equal(t, cmd.Name, "app")
 	assert.Equal(t, cmd.Args(), []string{})
 	assert.Equal(t, len(optCfgs), 27)
 	assert.True(t, options.BoolVal)
@@ -189,7 +189,7 @@ func TestParseFor_optionIsBoolAndArgIsName(t *testing.T) {
 	}
 	options := MyOptions{}
 
-	osArgs := []string{"app", "--flag", "abc"}
+	osArgs := []string{"path/to/app", "--flag", "abc"}
 	cmd, optCfgs, err := cliargs.ParseFor(osArgs, &options)
 
 	assert.Nil(t, err)
@@ -439,11 +439,11 @@ func TestParseFor_defaultValueIsInt(t *testing.T) {
 	}
 	options := MyOptions{}
 
-	osArgs := []string{}
+	osArgs := []string{"./app"}
 	cmd, optCfgs, err := cliargs.ParseFor(osArgs, &options)
 
 	assert.Nil(t, err)
-	assert.Equal(t, cmd.Name, "")
+	assert.Equal(t, cmd.Name, "app")
 	assert.Equal(t, cmd.Args(), []string{})
 	assert.Equal(t, len(optCfgs), 5)
 	assert.Equal(t, options.IntVal, 11)
@@ -463,11 +463,11 @@ func TestParseFor_defaultValueIsNegativeInt(t *testing.T) {
 	}
 	options := MyOptions{}
 
-	osArgs := []string{}
+	osArgs := []string{"/path/to/app"}
 	cmd, optCfgs, err := cliargs.ParseFor(osArgs, &options)
 
 	assert.Nil(t, err)
-	assert.Equal(t, cmd.Name, "")
+	assert.Equal(t, cmd.Name, "app")
 	assert.Equal(t, cmd.Args(), []string{})
 	assert.Equal(t, len(optCfgs), 5)
 	assert.Equal(t, options.IntVal, -11)
@@ -487,11 +487,11 @@ func TestParseFor_defaultValueIsUint(t *testing.T) {
 	}
 	options := MyOptions{}
 
-	osArgs := []string{}
+	osArgs := []string{"./app"}
 	cmd, optCfgs, err := cliargs.ParseFor(osArgs, &options)
 
 	assert.Nil(t, err)
-	assert.Equal(t, cmd.Name, "")
+	assert.Equal(t, cmd.Name, "app")
 	assert.Equal(t, cmd.Args(), []string{})
 	assert.Equal(t, len(optCfgs), 5)
 	assert.Equal(t, options.UintVal, uint(11))
@@ -508,11 +508,11 @@ func TestParseFor_defaultValueIsFloat(t *testing.T) {
 	}
 	options := MyOptions{}
 
-	osArgs := []string{}
+	osArgs := []string{"path/to/app"}
 	cmd, optCfgs, err := cliargs.ParseFor(osArgs, &options)
 
 	assert.Nil(t, err)
-	assert.Equal(t, cmd.Name, "")
+	assert.Equal(t, cmd.Name, "app")
 	assert.Equal(t, cmd.Args(), []string{})
 	assert.Equal(t, len(optCfgs), 2)
 	assert.Equal(t, options.Float32Val, float32(0.123))
@@ -526,11 +526,11 @@ func TestParseFor_defaultValueIsNegativeFloat(t *testing.T) {
 	}
 	options := MyOptions{}
 
-	osArgs := []string{}
+	osArgs := []string{"app"}
 	cmd, optCfgs, err := cliargs.ParseFor(osArgs, &options)
 
 	assert.Nil(t, err)
-	assert.Equal(t, cmd.Name, "")
+	assert.Equal(t, cmd.Name, "app")
 	assert.Equal(t, cmd.Args(), []string{})
 	assert.Equal(t, len(optCfgs), 2)
 	assert.Equal(t, options.Float32Val, float32(-0.123))
@@ -547,11 +547,11 @@ func TestParseFor_defaultValueIsIntArrayAndSize0(t *testing.T) {
 	}
 	options := MyOptions{}
 
-	osArgs := []string{}
+	osArgs := []string{"path/to/app"}
 	cmd, optCfgs, err := cliargs.ParseFor(osArgs, &options)
 
 	assert.Nil(t, err)
-	assert.Equal(t, cmd.Name, "")
+	assert.Equal(t, cmd.Name, "app")
 	assert.Equal(t, cmd.Args(), []string{})
 	assert.Equal(t, len(optCfgs), 5)
 	assert.Equal(t, options.IntArr, []int{})
@@ -577,11 +577,11 @@ func TestParseFor_overwriteIntArrayWithDefaultValueIfSize0(t *testing.T) {
 		Int64Arr: []int64{5},
 	}
 
-	osArgs := []string{}
+	osArgs := []string{"path/to/app"}
 	cmd, optCfgs, err := cliargs.ParseFor(osArgs, &options)
 
 	assert.Nil(t, err)
-	assert.Equal(t, cmd.Name, "")
+	assert.Equal(t, cmd.Name, "app")
 	assert.Equal(t, cmd.Args(), []string{})
 	assert.Equal(t, len(optCfgs), 5)
 	assert.Equal(t, options.IntArr, []int{})
@@ -601,11 +601,11 @@ func TestParseFor_defaultValueIsIntArrayAndSize1(t *testing.T) {
 	}
 	options := MyOptions{}
 
-	osArgs := []string{}
+	osArgs := []string{"path/to/app"}
 	cmd, optCfgs, err := cliargs.ParseFor(osArgs, &options)
 
 	assert.Nil(t, err)
-	assert.Equal(t, cmd.Name, "")
+	assert.Equal(t, cmd.Name, "app")
 	assert.Equal(t, cmd.Args(), []string{})
 	assert.Equal(t, len(optCfgs), 5)
 	assert.Equal(t, options.IntArr, []int{1})
@@ -631,11 +631,11 @@ func TestParseFor_overwriteIntArrayWithDefaultValueIfSize1(t *testing.T) {
 		Int64Arr: []int64{55},
 	}
 
-	osArgs := []string{}
+	osArgs := []string{"path/to/app"}
 	cmd, optCfgs, err := cliargs.ParseFor(osArgs, &options)
 
 	assert.Nil(t, err)
-	assert.Equal(t, cmd.Name, "")
+	assert.Equal(t, cmd.Name, "app")
 	assert.Equal(t, cmd.Args(), []string{})
 	assert.Equal(t, len(optCfgs), 5)
 	assert.Equal(t, options.IntArr, []int{1})
@@ -655,11 +655,11 @@ func TestParseFor_defaultValueIsIntArrayAndSize2(t *testing.T) {
 	}
 	options := MyOptions{}
 
-	osArgs := []string{}
+	osArgs := []string{"path/to/app"}
 	cmd, optCfgs, err := cliargs.ParseFor(osArgs, &options)
 
 	assert.Nil(t, err)
-	assert.Equal(t, cmd.Name, "")
+	assert.Equal(t, cmd.Name, "app")
 	assert.Equal(t, cmd.Args(), []string{})
 	assert.Equal(t, len(optCfgs), 5)
 	assert.Equal(t, options.IntArr, []int{1, 2})
@@ -685,11 +685,11 @@ func TestParseFor_overwriteIntArrayWithDefaultValueIfSize2(t *testing.T) {
 		Int64Arr: []int64{55},
 	}
 
-	osArgs := []string{}
+	osArgs := []string{"path/to/app"}
 	cmd, optCfgs, err := cliargs.ParseFor(osArgs, &options)
 
 	assert.Nil(t, err)
-	assert.Equal(t, cmd.Name, "")
+	assert.Equal(t, cmd.Name, "app")
 	assert.Equal(t, cmd.Args(), []string{})
 	assert.Equal(t, len(optCfgs), 5)
 	assert.Equal(t, options.IntArr, []int{1, 2})
@@ -709,11 +709,11 @@ func TestParseFor_defaultValueIsNegativeIntArray(t *testing.T) {
 	}
 	options := MyOptions{}
 
-	osArgs := []string{}
+	osArgs := []string{"path/to/app"}
 	cmd, optCfgs, err := cliargs.ParseFor(osArgs, &options)
 
 	assert.Nil(t, err)
-	assert.Equal(t, cmd.Name, "")
+	assert.Equal(t, cmd.Name, "app")
 	assert.Equal(t, cmd.Args(), []string{})
 	assert.Equal(t, len(optCfgs), 5)
 	assert.Equal(t, options.IntArr, []int{-1, -2})
@@ -733,11 +733,11 @@ func TestParseFor_defaultValueIsIntArraySeparatedByColons(t *testing.T) {
 	}
 	options := MyOptions{}
 
-	osArgs := []string{}
+	osArgs := []string{"/path/to/app"}
 	cmd, optCfgs, err := cliargs.ParseFor(osArgs, &options)
 
 	assert.Nil(t, err)
-	assert.Equal(t, cmd.Name, "")
+	assert.Equal(t, cmd.Name, "app")
 	assert.Equal(t, cmd.Args(), []string{})
 	assert.Equal(t, len(optCfgs), 5)
 	assert.Equal(t, options.IntArr, []int{-1, -2})
@@ -757,11 +757,11 @@ func TestParseFor_defaultValueIsUintArrayAndSize0(t *testing.T) {
 	}
 	options := MyOptions{}
 
-	osArgs := []string{}
+	osArgs := []string{"/path/to/app"}
 	cmd, optCfgs, err := cliargs.ParseFor(osArgs, &options)
 
 	assert.Nil(t, err)
-	assert.Equal(t, cmd.Name, "")
+	assert.Equal(t, cmd.Name, "app")
 	assert.Equal(t, cmd.Args(), []string{})
 	assert.Equal(t, len(optCfgs), 5)
 	assert.Equal(t, options.UintArr, []uint{})
@@ -787,11 +787,11 @@ func TestParseFor_overwriteUintArrayWithDefaultValueIfSize0(t *testing.T) {
 		Uint64Arr: []uint64{5},
 	}
 
-	osArgs := []string{}
+	osArgs := []string{"/path/to/app"}
 	cmd, optCfgs, err := cliargs.ParseFor(osArgs, &options)
 
 	assert.Nil(t, err)
-	assert.Equal(t, cmd.Name, "")
+	assert.Equal(t, cmd.Name, "app")
 	assert.Equal(t, cmd.Args(), []string{})
 	assert.Equal(t, len(optCfgs), 5)
 	assert.Equal(t, options.UintArr, []uint{})
@@ -811,11 +811,11 @@ func TestParseFor_defaultValueIsUintArrayAndSize1(t *testing.T) {
 	}
 	options := MyOptions{}
 
-	osArgs := []string{}
+	osArgs := []string{"/path/to/app"}
 	cmd, optCfgs, err := cliargs.ParseFor(osArgs, &options)
 
 	assert.Nil(t, err)
-	assert.Equal(t, cmd.Name, "")
+	assert.Equal(t, cmd.Name, "app")
 	assert.Equal(t, cmd.Args(), []string{})
 	assert.Equal(t, len(optCfgs), 5)
 	assert.Equal(t, options.UintArr, []uint{1})
@@ -841,11 +841,11 @@ func TestParseFor_overwriteUintArrayWithDefaultValueIfSize1(t *testing.T) {
 		Uint64Arr: []uint64{55},
 	}
 
-	osArgs := []string{}
+	osArgs := []string{"path/to/app"}
 	cmd, optCfgs, err := cliargs.ParseFor(osArgs, &options)
 
 	assert.Nil(t, err)
-	assert.Equal(t, cmd.Name, "")
+	assert.Equal(t, cmd.Name, "app")
 	assert.Equal(t, cmd.Args(), []string{})
 	assert.Equal(t, len(optCfgs), 5)
 	assert.Equal(t, options.UintArr, []uint{1})
@@ -865,11 +865,11 @@ func TestParseFor_defaultValueIsUintArrayAndSize2(t *testing.T) {
 	}
 	options := MyOptions{}
 
-	osArgs := []string{}
+	osArgs := []string{"/path/to/app"}
 	cmd, optCfgs, err := cliargs.ParseFor(osArgs, &options)
 
 	assert.Nil(t, err)
-	assert.Equal(t, cmd.Name, "")
+	assert.Equal(t, cmd.Name, "app")
 	assert.Equal(t, cmd.Args(), []string{})
 	assert.Equal(t, len(optCfgs), 5)
 	assert.Equal(t, options.UintArr, []uint{1, 2})
@@ -895,11 +895,11 @@ func TestParseFor_overwriteUintArrayWithDefaultValueIfSize2(t *testing.T) {
 		Uint64Arr: []uint64{55},
 	}
 
-	osArgs := []string{}
+	osArgs := []string{"./app"}
 	cmd, optCfgs, err := cliargs.ParseFor(osArgs, &options)
 
 	assert.Nil(t, err)
-	assert.Equal(t, cmd.Name, "")
+	assert.Equal(t, cmd.Name, "app")
 	assert.Equal(t, cmd.Args(), []string{})
 	assert.Equal(t, len(optCfgs), 5)
 	assert.Equal(t, options.UintArr, []uint{1, 2})
@@ -919,11 +919,11 @@ func TestParseFor_defaultValueIsUintArraySeparatedByColons(t *testing.T) {
 	}
 	options := MyOptions{}
 
-	osArgs := []string{}
+	osArgs := []string{"app"}
 	cmd, optCfgs, err := cliargs.ParseFor(osArgs, &options)
 
 	assert.Nil(t, err)
-	assert.Equal(t, cmd.Name, "")
+	assert.Equal(t, cmd.Name, "app")
 	assert.Equal(t, cmd.Args(), []string{})
 	assert.Equal(t, len(optCfgs), 5)
 	assert.Equal(t, options.UintArr, []uint{1, 2})
@@ -940,11 +940,11 @@ func TestParseFor_defaultValueIsFloatArrayAndSize0(t *testing.T) {
 	}
 	options := MyOptions{}
 
-	osArgs := []string{}
+	osArgs := []string{"./app"}
 	cmd, optCfgs, err := cliargs.ParseFor(osArgs, &options)
 
 	assert.Nil(t, err)
-	assert.Equal(t, cmd.Name, "")
+	assert.Equal(t, cmd.Name, "app")
 	assert.Equal(t, cmd.Args(), []string{})
 	assert.Equal(t, len(optCfgs), 2)
 	assert.Equal(t, options.Float32Arr, []float32{})
@@ -961,11 +961,11 @@ func TestParseFor_overwriteFloatArrayWithDefaultValueIfSize0(t *testing.T) {
 		Float64Arr: []float64{0.888},
 	}
 
-	osArgs := []string{}
+	osArgs := []string{"./app"}
 	cmd, optCfgs, err := cliargs.ParseFor(osArgs, &options)
 
 	assert.Nil(t, err)
-	assert.Equal(t, cmd.Name, "")
+	assert.Equal(t, cmd.Name, "app")
 	assert.Equal(t, cmd.Args(), []string{})
 	assert.Equal(t, len(optCfgs), 2)
 	assert.Equal(t, options.Float32Arr, []float32{})
@@ -979,11 +979,11 @@ func TestParseFor_defaultValueIsFloatArrayAndSize1(t *testing.T) {
 	}
 	options := MyOptions{}
 
-	osArgs := []string{}
+	osArgs := []string{"/path/to/app"}
 	cmd, optCfgs, err := cliargs.ParseFor(osArgs, &options)
 
 	assert.Nil(t, err)
-	assert.Equal(t, cmd.Name, "")
+	assert.Equal(t, cmd.Name, "app")
 	assert.Equal(t, cmd.Args(), []string{})
 	assert.Equal(t, len(optCfgs), 2)
 	assert.Equal(t, options.Float32Arr, []float32{0.1})
@@ -1000,11 +1000,11 @@ func TestParseFor_overwriteFloatArrayWithDefaultValueIfSize1(t *testing.T) {
 		Float64Arr: []float64{0.88},
 	}
 
-	osArgs := []string{}
+	osArgs := []string{"/path/to/app"}
 	cmd, optCfgs, err := cliargs.ParseFor(osArgs, &options)
 
 	assert.Nil(t, err)
-	assert.Equal(t, cmd.Name, "")
+	assert.Equal(t, cmd.Name, "app")
 	assert.Equal(t, cmd.Args(), []string{})
 	assert.Equal(t, len(optCfgs), 2)
 	assert.Equal(t, options.Float32Arr, []float32{0.1})
@@ -1018,11 +1018,11 @@ func TestParseFor_defaultValueIsFloatArrayAndSize2(t *testing.T) {
 	}
 	options := MyOptions{}
 
-	osArgs := []string{}
+	osArgs := []string{"/path/to/app"}
 	cmd, optCfgs, err := cliargs.ParseFor(osArgs, &options)
 
 	assert.Nil(t, err)
-	assert.Equal(t, cmd.Name, "")
+	assert.Equal(t, cmd.Name, "app")
 	assert.Equal(t, cmd.Args(), []string{})
 	assert.Equal(t, len(optCfgs), 2)
 	assert.Equal(t, options.Float32Arr, []float32{0.1, 0.2})
@@ -1039,11 +1039,11 @@ func TestParseFor_overwriteFloatArrayWithDefaultValueIfSize2(t *testing.T) {
 		Float64Arr: []float64{0.88},
 	}
 
-	osArgs := []string{}
+	osArgs := []string{"/path/to/app"}
 	cmd, optCfgs, err := cliargs.ParseFor(osArgs, &options)
 
 	assert.Nil(t, err)
-	assert.Equal(t, cmd.Name, "")
+	assert.Equal(t, cmd.Name, "app")
 	assert.Equal(t, cmd.Args(), []string{})
 	assert.Equal(t, len(optCfgs), 2)
 	assert.Equal(t, options.Float32Arr, []float32{0.1, 0.2})
@@ -1057,11 +1057,11 @@ func TestParseFor_defaultValueIsNegativeFloatArray(t *testing.T) {
 	}
 	options := MyOptions{}
 
-	osArgs := []string{}
+	osArgs := []string{"/path/to/app"}
 	cmd, optCfgs, err := cliargs.ParseFor(osArgs, &options)
 
 	assert.Nil(t, err)
-	assert.Equal(t, cmd.Name, "")
+	assert.Equal(t, cmd.Name, "app")
 	assert.Equal(t, cmd.Args(), []string{})
 	assert.Equal(t, len(optCfgs), 2)
 	assert.Equal(t, options.Float32Arr, []float32{-0.1, -0.2})
@@ -1075,11 +1075,11 @@ func TestParseFor_defaultValueIsFloatArraySeparatedByColons(t *testing.T) {
 	}
 	options := MyOptions{}
 
-	osArgs := []string{}
+	osArgs := []string{"/path/to/app"}
 	cmd, optCfgs, err := cliargs.ParseFor(osArgs, &options)
 
 	assert.Nil(t, err)
-	assert.Equal(t, cmd.Name, "")
+	assert.Equal(t, cmd.Name, "app")
 	assert.Equal(t, cmd.Args(), []string{})
 	assert.Equal(t, len(optCfgs), 2)
 	assert.Equal(t, options.Float32Arr, []float32{-0.1, -0.2})
@@ -1092,11 +1092,11 @@ func TestParseFor_defaultValueIsStringAndSize0(t *testing.T) {
 	}
 	options := MyOptions{}
 
-	osArgs := []string{}
+	osArgs := []string{"/path/to/app"}
 	cmd, optCfgs, err := cliargs.ParseFor(osArgs, &options)
 
 	assert.Nil(t, err)
-	assert.Equal(t, cmd.Name, "")
+	assert.Equal(t, cmd.Name, "app")
 	assert.Equal(t, cmd.Args(), []string{})
 	assert.Equal(t, len(optCfgs), 1)
 	assert.Equal(t, options.StringArr, []string{})
@@ -1110,11 +1110,11 @@ func TestParseFor_overwriteStringArrayWithDefaultValueIfSize0(t *testing.T) {
 		StringArr: []string{"ZZZ"},
 	}
 
-	osArgs := []string{}
+	osArgs := []string{"/path/to/app"}
 	cmd, optCfgs, err := cliargs.ParseFor(osArgs, &options)
 
 	assert.Nil(t, err)
-	assert.Equal(t, cmd.Name, "")
+	assert.Equal(t, cmd.Name, "app")
 	assert.Equal(t, cmd.Args(), []string{})
 	assert.Equal(t, len(optCfgs), 1)
 	assert.Equal(t, options.StringArr, []string{})
@@ -1126,11 +1126,11 @@ func TestParseFor_defaultValueIsStringArrayAndSize1(t *testing.T) {
 	}
 	options := MyOptions{}
 
-	osArgs := []string{}
+	osArgs := []string{"/path/to/app"}
 	cmd, optCfgs, err := cliargs.ParseFor(osArgs, &options)
 
 	assert.Nil(t, err)
-	assert.Equal(t, cmd.Name, "")
+	assert.Equal(t, cmd.Name, "app")
 	assert.Equal(t, cmd.Args(), []string{})
 	assert.Equal(t, len(optCfgs), 1)
 	assert.Equal(t, options.StringArr, []string{"ABC"})
@@ -1144,11 +1144,11 @@ func TestParseFor_overwriteStringArrayWithDefaultValueIfSize1(t *testing.T) {
 		StringArr: []string{"ZZZ"},
 	}
 
-	osArgs := []string{}
+	osArgs := []string{"/path/to/app"}
 	cmd, optCfgs, err := cliargs.ParseFor(osArgs, &options)
 
 	assert.Nil(t, err)
-	assert.Equal(t, cmd.Name, "")
+	assert.Equal(t, cmd.Name, "app")
 	assert.Equal(t, cmd.Args(), []string{})
 	assert.Equal(t, len(optCfgs), 1)
 	assert.Equal(t, options.StringArr, []string{"ABC"})
@@ -1160,11 +1160,11 @@ func TestParseFor_defaultValueIsStringArrayAndSize2(t *testing.T) {
 	}
 	options := MyOptions{}
 
-	osArgs := []string{}
+	osArgs := []string{"/path/to/app"}
 	cmd, optCfgs, err := cliargs.ParseFor(osArgs, &options)
 
 	assert.Nil(t, err)
-	assert.Equal(t, cmd.Name, "")
+	assert.Equal(t, cmd.Name, "app")
 	assert.Equal(t, cmd.Args(), []string{})
 	assert.Equal(t, len(optCfgs), 1)
 	assert.Equal(t, options.StringArr, []string{"ABC", "DEF"})
@@ -1178,11 +1178,11 @@ func TestParseFor_overwriteStringArrayWithDefaultValueIfSize2(t *testing.T) {
 		StringArr: []string{"ZZZ"},
 	}
 
-	osArgs := []string{}
+	osArgs := []string{"/path/to/app"}
 	cmd, optCfgs, err := cliargs.ParseFor(osArgs, &options)
 
 	assert.Nil(t, err)
-	assert.Equal(t, cmd.Name, "")
+	assert.Equal(t, cmd.Name, "app")
 	assert.Equal(t, cmd.Args(), []string{})
 	assert.Equal(t, len(optCfgs), 1)
 	assert.Equal(t, options.StringArr, []string{"ABC", "DEF"})
@@ -1194,11 +1194,11 @@ func TestParseFor_defaultValueIsStringArraySeparatedByColons(t *testing.T) {
 	}
 	options := MyOptions{}
 
-	osArgs := []string{}
+	osArgs := []string{"/path/to/app"}
 	cmd, optCfgs, err := cliargs.ParseFor(osArgs, &options)
 
 	assert.Nil(t, err)
-	assert.Equal(t, cmd.Name, "")
+	assert.Equal(t, cmd.Name, "app")
 	assert.Equal(t, cmd.Args(), []string{})
 	assert.Equal(t, len(optCfgs), 1)
 	assert.Equal(t, options.StringArr, []string{"ABC", "DEF"})
@@ -1210,11 +1210,11 @@ func TestParseFor_ignoreEmptyDefaultValueIfOptionIsBool(t *testing.T) {
 	}
 	options := MyOptions{}
 
-	osArgs := []string{}
+	osArgs := []string{"/path/to/app"}
 	cmd, optCfgs, err := cliargs.ParseFor(osArgs, &options)
 
 	assert.Nil(t, err)
-	assert.Equal(t, cmd.Name, "")
+	assert.Equal(t, cmd.Name, "app")
 	assert.Equal(t, cmd.Args(), []string{})
 	assert.Equal(t, len(optCfgs), 1)
 	assert.False(t, options.BoolVar)
@@ -1226,10 +1226,10 @@ func TestParseFor_errorEmptyDefaultValueIfOptionIsInt(t *testing.T) {
 	}
 	options := MyOptions{}
 
-	osArgs := []string{}
+	osArgs := []string{"/path/to/app"}
 	cmd, optCfgs, err := cliargs.ParseFor(osArgs, &options)
 
-	assert.Equal(t, cmd.Name, "")
+	assert.Equal(t, cmd.Name, "app")
 	assert.Equal(t, cmd.Args(), []string{})
 	assert.Equal(t, len(optCfgs), 1)
 	assert.NotNil(t, err)
@@ -1255,10 +1255,10 @@ func TestParseFor_errorEmptyDefaultValueIfOptionIsUint(t *testing.T) {
 	}
 	options := MyOptions{}
 
-	osArgs := []string{}
+	osArgs := []string{"/path/to/app"}
 	cmd, optCfgs, err := cliargs.ParseFor(osArgs, &options)
 
-	assert.Equal(t, cmd.Name, "")
+	assert.Equal(t, cmd.Name, "app")
 	assert.Equal(t, cmd.Args(), []string{})
 	assert.Equal(t, len(optCfgs), 1)
 	assert.NotNil(t, err)
@@ -1284,10 +1284,10 @@ func TestParseFor_errorEmptyDefaultValueIfOptionIsFloat(t *testing.T) {
 	}
 	options := MyOptions{}
 
-	osArgs := []string{}
+	osArgs := []string{"/path/to/app"}
 	cmd, optCfgs, err := cliargs.ParseFor(osArgs, &options)
 
-	assert.Equal(t, cmd.Name, "")
+	assert.Equal(t, cmd.Name, "app")
 	assert.Equal(t, cmd.Args(), []string{})
 	assert.Equal(t, len(optCfgs), 1)
 	assert.NotNil(t, err)
@@ -1313,11 +1313,11 @@ func TestParseFor_errorEmptyDefaultValueIfOptionIsString(t *testing.T) {
 	}
 	options := MyOptions{}
 
-	osArgs := []string{}
+	osArgs := []string{"/path/to/app"}
 	cmd, optCfgs, err := cliargs.ParseFor(osArgs, &options)
 
 	assert.Nil(t, err)
-	assert.Equal(t, cmd.Name, "")
+	assert.Equal(t, cmd.Name, "app")
 	assert.Equal(t, cmd.Args(), []string{})
 	assert.Equal(t, len(optCfgs), 1)
 	assert.Equal(t, options.StringVar, "")
@@ -1329,10 +1329,10 @@ func TestParseFor_errorEmptyDefaultValueIfOptionIsIntArray(t *testing.T) {
 	}
 	options := MyOptions{}
 
-	osArgs := []string{}
+	osArgs := []string{"/path/to/app"}
 	cmd, optCfgs, err := cliargs.ParseFor(osArgs, &options)
 
-	assert.Equal(t, cmd.Name, "")
+	assert.Equal(t, cmd.Name, "app")
 	assert.Equal(t, cmd.Args(), []string{})
 	assert.Equal(t, len(optCfgs), 1)
 	assert.NotNil(t, err)
@@ -1358,10 +1358,10 @@ func TestParseFor_errorEmptyDefaultValueIfOptionIsUintArray(t *testing.T) {
 	}
 	options := MyOptions{}
 
-	osArgs := []string{}
+	osArgs := []string{"/path/to/app"}
 	cmd, optCfgs, err := cliargs.ParseFor(osArgs, &options)
 
-	assert.Equal(t, cmd.Name, "")
+	assert.Equal(t, cmd.Name, "app")
 	assert.Equal(t, cmd.Args(), []string{})
 	assert.Equal(t, len(optCfgs), 1)
 	assert.NotNil(t, err)
@@ -1387,10 +1387,10 @@ func TestParseFor_errorEmptyDefaultValueIfOptionIsFloatArray(t *testing.T) {
 	}
 	options := MyOptions{}
 
-	osArgs := []string{}
+	osArgs := []string{"/path/to/app"}
 	cmd, optCfgs, err := cliargs.ParseFor(osArgs, &options)
 
-	assert.Equal(t, cmd.Name, "")
+	assert.Equal(t, cmd.Name, "app")
 	assert.Equal(t, cmd.Args(), []string{})
 	assert.Equal(t, len(optCfgs), 1)
 	assert.NotNil(t, err)
@@ -1416,11 +1416,11 @@ func TestParseFor_optionIsStringArrayAndSetOneEmptyStringByDefaultArray(t *testi
 	}
 	options := MyOptions{}
 
-	osArgs := []string{}
+	osArgs := []string{"/path/to/app"}
 	cmd, optCfgs, err := cliargs.ParseFor(osArgs, &options)
 
 	assert.Nil(t, err)
-	assert.Equal(t, cmd.Name, "")
+	assert.Equal(t, cmd.Name, "app")
 	assert.Equal(t, cmd.Args(), []string{})
 	assert.Equal(t, len(optCfgs), 1)
 	assert.Equal(t, options.StringArr, []string{""})
@@ -1432,11 +1432,11 @@ func TestParseFor_defaultValueIsIgnoreWhenTypeIsBool(t *testing.T) {
 	}
 	options := MyOptions{}
 
-	osArgs := []string{}
+	osArgs := []string{"/path/to/app"}
 	cmd, optCfgs, err := cliargs.ParseFor(osArgs, &options)
 
 	assert.Nil(t, err)
-	assert.Equal(t, cmd.Name, "")
+	assert.Equal(t, cmd.Name, "app")
 	assert.Equal(t, cmd.Args(), []string{})
 	assert.Equal(t, len(optCfgs), 1)
 	assert.False(t, options.BoolVar)
@@ -1448,10 +1448,10 @@ func TestParseFor_errorIfDefaultValueIsInvalidType(t *testing.T) {
 	}
 	options := MyOptions{}
 
-	osArgs := []string{}
+	osArgs := []string{"/path/to/app"}
 	cmd, optCfgs, err := cliargs.ParseFor(osArgs, &options)
 
-	assert.Equal(t, cmd.Name, "")
+	assert.Equal(t, cmd.Name, "app")
 	assert.Equal(t, cmd.Args(), []string{})
 	assert.Equal(t, len(optCfgs), 0) // because of the error
 	assert.NotNil(t, err)
@@ -1581,10 +1581,10 @@ func TestParseFor_emptyArrayOfDefaultValueWithNotCommaSeparator(t *testing.T) {
 	}
 	options := MyOptions{}
 
-	args := []string{}
+	args := []string{"/path/to/app"}
 	cmd, optCfgs, err := cliargs.ParseFor(args, &options)
 	assert.Nil(t, err)
-	assert.Equal(t, cmd.Name, "")
+	assert.Equal(t, cmd.Name, "app")
 	assert.Equal(t, cmd.Args(), []string{})
 	assert.Equal(t, len(optCfgs), 4)
 	assert.Equal(t, options.Foo, []int{})

--- a/parse-with_test.go
+++ b/parse-with_test.go
@@ -11,11 +11,11 @@ import (
 func TestParseWith_zeroCfgAndZeroArg(t *testing.T) {
 	optCfgs := []cliargs.OptCfg{}
 
-	osArgs := []string{}
+	osArgs := []string{"app"}
 
 	cmd, err := cliargs.ParseWith(osArgs, optCfgs)
 	assert.Nil(t, err)
-	assert.Equal(t, cmd.Name, "")
+	assert.Equal(t, cmd.Name, "app")
 	assert.False(t, cmd.HasOpt("foo-bar"))
 	assert.Equal(t, cmd.OptArg("foo-bar"), "")
 	assert.Equal(t, cmd.OptArgs("foo-bar"), []string(nil))
@@ -74,7 +74,7 @@ func TestParseWith_zeroCfgAndOneShortOpt(t *testing.T) {
 	default:
 		assert.Fail(t, err.Error())
 	}
-	assert.Equal(t, cmd.Name, "")
+	assert.Equal(t, cmd.Name, "app")
 	assert.False(t, cmd.HasOpt("foo-bar"))
 	assert.Equal(t, cmd.OptArg("foo-bar"), "")
 	assert.Equal(t, cmd.OptArgs("foo-bar"), []string(nil))
@@ -89,11 +89,11 @@ func TestParseWith_oneCfgAndZeroOpt(t *testing.T) {
 		cliargs.OptCfg{Name: "foo-bar"},
 	}
 
-	osArgs := []string{}
+	osArgs := []string{"app"}
 
 	cmd, err := cliargs.ParseWith(osArgs, optCfgs)
 	assert.Nil(t, err)
-	assert.Equal(t, cmd.Name, "")
+	assert.Equal(t, cmd.Name, "app")
 	assert.False(t, cmd.HasOpt("foo-bar"))
 	assert.Equal(t, cmd.OptArg("foo-bar"), "")
 	assert.Equal(t, cmd.OptArgs("foo-bar"), []string(nil))
@@ -176,7 +176,7 @@ func TestParseWith_oneCfgAndOneDifferentLongOpt(t *testing.T) {
 	default:
 		assert.Fail(t, err.Error())
 	}
-	assert.Equal(t, cmd.Name, "")
+	assert.Equal(t, cmd.Name, "app")
 	assert.False(t, cmd.HasOpt("foo-bar"))
 	assert.Equal(t, cmd.OptArg("foo-bar"), "")
 	assert.Equal(t, cmd.OptArgs("foo-bar"), []string(nil))
@@ -202,7 +202,7 @@ func TestParseWith_oneCfgAndOneDifferentShortOpt(t *testing.T) {
 	default:
 		assert.Fail(t, err.Error())
 	}
-	assert.Equal(t, cmd.Name, "")
+	assert.Equal(t, cmd.Name, "app")
 	assert.False(t, cmd.HasOpt("foo-bar"))
 	assert.Equal(t, cmd.OptArg("foo-bar"), "")
 	assert.Equal(t, cmd.OptArgs("foo-bar"), []string(nil))
@@ -246,6 +246,7 @@ func TestParseWith_anyOptCfgAndOneDifferentShortOpt(t *testing.T) {
 
 	cmd, err := cliargs.ParseWith(osArgs, optCfgs)
 	assert.Nil(t, err)
+	assert.Equal(t, cmd.Name, "app")
 	assert.False(t, cmd.HasOpt("foo-bar"))
 	assert.Equal(t, cmd.OptArg("foo-bar"), "")
 	assert.Equal(t, cmd.OptArgs("foo-bar"), []string(nil))
@@ -391,6 +392,7 @@ func TestParseWith_oneCfgHasArgButOneLongOptHasNoArg(t *testing.T) {
 	default:
 		assert.Fail(t, err.Error())
 	}
+	assert.Equal(t, cmd.Name, "app")
 	assert.False(t, cmd.HasOpt("foo-bar"))
 	assert.Equal(t, cmd.OptArg("foo-bar"), "")
 	assert.Equal(t, cmd.OptArgs("foo-bar"), []string(nil))
@@ -416,6 +418,7 @@ func TestParseWith_oneCfgHasArgAndOneShortOptHasNoArg(t *testing.T) {
 	default:
 		assert.Fail(t, err.Error())
 	}
+	assert.Equal(t, cmd.Name, "app")
 	assert.False(t, cmd.HasOpt("foo-bar"))
 	assert.Equal(t, cmd.OptArg("foo-bar"), "")
 	assert.Equal(t, cmd.OptArgs("foo-bar"), []string(nil))
@@ -434,6 +437,7 @@ func TestParseWith_oneCfgHasNoArgAndOneLongOptHasArg(t *testing.T) {
 
 	cmd, err := cliargs.ParseWith(osArgs, optCfgs)
 	assert.Nil(t, err)
+	assert.Equal(t, cmd.Name, "app")
 	assert.True(t, cmd.HasOpt("foo-bar"))
 	assert.Equal(t, cmd.OptArg("foo-bar"), "")
 	assert.Equal(t, cmd.OptArgs("foo-bar"), []string{})
@@ -453,6 +457,7 @@ func TestParseWith_oneCfgHasNoArgAndOneLongOptHasArg(t *testing.T) {
 	default:
 		assert.Fail(t, err.Error())
 	}
+	assert.Equal(t, cmd.Name, "app")
 	assert.False(t, cmd.HasOpt("foo-bar"))
 	assert.Equal(t, cmd.OptArg("foo-bar"), "")
 	assert.Equal(t, cmd.OptArgs("foo-bar"), []string(nil))
@@ -465,6 +470,7 @@ func TestParseWith_oneCfgHasNoArgAndOneLongOptHasArg(t *testing.T) {
 
 	cmd, err = cliargs.ParseWith(osArgs, optCfgs)
 	assert.Nil(t, err)
+	assert.Equal(t, cmd.Name, "app")
 	assert.True(t, cmd.HasOpt("foo-bar"))
 	assert.Equal(t, cmd.OptArg("foo-bar"), "")
 	assert.Equal(t, cmd.OptArgs("foo-bar"), []string{})
@@ -484,6 +490,7 @@ func TestParseWith_oneCfgHasNoArgAndOneLongOptHasArg(t *testing.T) {
 	default:
 		assert.Fail(t, err.Error())
 	}
+	assert.Equal(t, cmd.Name, "app")
 	assert.False(t, cmd.HasOpt("foo-bar"))
 	assert.Equal(t, cmd.OptArg("foo-bar"), "")
 	assert.Equal(t, cmd.OptArgs("foo-bar"), []string(nil))
@@ -502,6 +509,7 @@ func TestParseWith_oneCfgHasNoArgAndOneShortOptHasArg(t *testing.T) {
 
 	cmd, err := cliargs.ParseWith(osArgs, optCfgs)
 	assert.Nil(t, err)
+	assert.Equal(t, cmd.Name, "app")
 	assert.False(t, cmd.HasOpt("foo-bar"))
 	assert.Equal(t, cmd.OptArg("foo-bar"), "")
 	assert.Equal(t, cmd.OptArgs("foo-bar"), []string(nil))
@@ -522,6 +530,7 @@ func TestParseWith_oneCfgHasNoArgAndOneShortOptHasArg(t *testing.T) {
 		assert.Fail(t, err.Error())
 	}
 
+	assert.Equal(t, cmd.Name, "app")
 	assert.False(t, cmd.HasOpt("foo-bar"))
 	assert.Equal(t, cmd.OptArg("foo-bar"), "")
 	assert.Equal(t, cmd.OptArgs("foo-bar"), []string(nil))
@@ -534,6 +543,7 @@ func TestParseWith_oneCfgHasNoArgAndOneShortOptHasArg(t *testing.T) {
 
 	cmd, err = cliargs.ParseWith(osArgs, optCfgs)
 	assert.Nil(t, err)
+	assert.Equal(t, cmd.Name, "app")
 	assert.False(t, cmd.HasOpt("foo-bar"))
 	assert.Equal(t, cmd.OptArg("foo-bar"), "")
 	assert.Equal(t, cmd.OptArgs("foo-bar"), []string(nil))
@@ -554,6 +564,7 @@ func TestParseWith_oneCfgHasNoArgAndOneShortOptHasArg(t *testing.T) {
 		assert.Fail(t, err.Error())
 	}
 
+	assert.Equal(t, cmd.Name, "app")
 	assert.False(t, cmd.HasOpt("foo-bar"))
 	assert.Equal(t, cmd.OptArg("foo-bar"), "")
 	assert.Equal(t, cmd.OptArgs("foo-bar"), []string(nil))
@@ -579,6 +590,7 @@ func TestParseWith_oneCfgHasNoArgButIsArray(t *testing.T) {
 	default:
 		assert.Fail(t, err.Error())
 	}
+	assert.Equal(t, cmd.Name, "app")
 	assert.False(t, cmd.HasOpt("foo-bar"))
 	assert.Equal(t, cmd.OptArg("foo-bar"), "")
 	assert.Equal(t, cmd.OptArgs("foo-bar"), []string(nil))
@@ -598,6 +610,7 @@ func TestParseWith_oneCfgIsArrayAndOptHasOneArg(t *testing.T) {
 
 	cmd, err := cliargs.ParseWith(osArgs, optCfgs)
 	assert.Nil(t, err)
+	assert.Equal(t, cmd.Name, "app")
 	assert.True(t, cmd.HasOpt("foo-bar"))
 	assert.Equal(t, cmd.OptArg("foo-bar"), "ABC")
 	assert.Equal(t, cmd.OptArgs("foo-bar"), []string{"ABC"})
@@ -610,6 +623,7 @@ func TestParseWith_oneCfgIsArrayAndOptHasOneArg(t *testing.T) {
 
 	cmd, err = cliargs.ParseWith(osArgs, optCfgs)
 	assert.Nil(t, err)
+	assert.Equal(t, cmd.Name, "app")
 	assert.True(t, cmd.HasOpt("foo-bar"))
 	assert.Equal(t, cmd.OptArg("foo-bar"), "ABC")
 	assert.Equal(t, cmd.OptArgs("foo-bar"), []string{"ABC", "DEF"})
@@ -622,6 +636,7 @@ func TestParseWith_oneCfgIsArrayAndOptHasOneArg(t *testing.T) {
 
 	cmd, err = cliargs.ParseWith(osArgs, optCfgs)
 	assert.Nil(t, err)
+	assert.Equal(t, cmd.Name, "app")
 	assert.False(t, cmd.HasOpt("foo-bar"))
 	assert.Equal(t, cmd.OptArg("foo-bar"), "")
 	assert.Equal(t, cmd.OptArgs("foo-bar"), []string(nil))
@@ -634,6 +649,7 @@ func TestParseWith_oneCfgIsArrayAndOptHasOneArg(t *testing.T) {
 
 	cmd, err = cliargs.ParseWith(osArgs, optCfgs)
 	assert.Nil(t, err)
+	assert.Equal(t, cmd.Name, "app")
 	assert.False(t, cmd.HasOpt("foo-bar"))
 	assert.Equal(t, cmd.OptArg("foo-bar"), "")
 	assert.Equal(t, cmd.OptArgs("foo-bar"), []string(nil))
@@ -656,6 +672,7 @@ func TestParseWith_oneCfgHasAliasesAndArgMatchesName(t *testing.T) {
 
 	cmd, err := cliargs.ParseWith(osArgs, optCfgs)
 	assert.Nil(t, err)
+	assert.Equal(t, cmd.Name, "app")
 	assert.True(t, cmd.HasOpt("foo-bar"))
 	assert.Equal(t, cmd.OptArg("foo-bar"), "ABC")
 	assert.Equal(t, cmd.OptArgs("foo-bar"), []string{"ABC"})
@@ -668,6 +685,7 @@ func TestParseWith_oneCfgHasAliasesAndArgMatchesName(t *testing.T) {
 
 	cmd, err = cliargs.ParseWith(osArgs, optCfgs)
 	assert.Nil(t, err)
+	assert.Equal(t, cmd.Name, "app")
 	assert.True(t, cmd.HasOpt("foo-bar"))
 	assert.Equal(t, cmd.OptArg("foo-bar"), "ABC")
 	assert.Equal(t, cmd.OptArgs("foo-bar"), []string{"ABC"})
@@ -690,6 +708,7 @@ func TestParseWith_oneCfgHasAliasesAndArgMatchesAliases(t *testing.T) {
 
 	cmd, err := cliargs.ParseWith(osArgs, optCfgs)
 	assert.Nil(t, err)
+	assert.Equal(t, cmd.Name, "app")
 	assert.True(t, cmd.HasOpt("foo-bar"))
 	assert.Equal(t, cmd.OptArg("foo-bar"), "ABC")
 	assert.Equal(t, cmd.OptArgs("foo-bar"), []string{"ABC"})
@@ -702,6 +721,7 @@ func TestParseWith_oneCfgHasAliasesAndArgMatchesAliases(t *testing.T) {
 
 	cmd, err = cliargs.ParseWith(osArgs, optCfgs)
 	assert.Nil(t, err)
+	assert.Equal(t, cmd.Name, "app")
 	assert.True(t, cmd.HasOpt("foo-bar"))
 	assert.Equal(t, cmd.OptArg("foo-bar"), "ABC")
 	assert.Equal(t, cmd.OptArgs("foo-bar"), []string{"ABC"})
@@ -725,6 +745,7 @@ func TestParseWith_combineOptsByNameAndAliases(t *testing.T) {
 
 	cmd, err := cliargs.ParseWith(osArgs, optCfgs)
 	assert.Nil(t, err)
+	assert.Equal(t, cmd.Name, "app")
 	assert.True(t, cmd.HasOpt("foo-bar"))
 	assert.Equal(t, cmd.OptArg("foo-bar"), "ABC")
 	assert.Equal(t, cmd.OptArgs("foo-bar"), []string{"ABC", "DEF"})
@@ -737,6 +758,7 @@ func TestParseWith_combineOptsByNameAndAliases(t *testing.T) {
 
 	cmd, err = cliargs.ParseWith(osArgs, optCfgs)
 	assert.Nil(t, err)
+	assert.Equal(t, cmd.Name, "app")
 	assert.True(t, cmd.HasOpt("foo-bar"))
 	assert.Equal(t, cmd.OptArg("foo-bar"), "ABC")
 	assert.Equal(t, cmd.OptArgs("foo-bar"), []string{"ABC", "DEF"})
@@ -767,10 +789,10 @@ func TestParseWith_oneCfgIsNotArrayButOptsAreMultiple(t *testing.T) {
 	default:
 		assert.Fail(t, err.Error())
 	}
-	assert.Equal(t, cmd.Name, "")
-	assert.False(t, cmd.HasOpt("foo-bar"))
-	assert.Equal(t, cmd.OptArg("foo-bar"), "")
-	assert.Equal(t, cmd.OptArgs("foo-bar"), []string(nil))
+	assert.Equal(t, cmd.Name, "app")
+	assert.True(t, cmd.HasOpt("foo-bar"))
+	assert.Equal(t, cmd.OptArg("foo-bar"), "ABC")
+	assert.Equal(t, cmd.OptArgs("foo-bar"), []string{"ABC"})
 	assert.False(t, cmd.HasOpt("f"))
 	assert.Equal(t, cmd.OptArg("f"), "")
 	assert.Equal(t, cmd.OptArgs("f"), []string(nil))
@@ -778,7 +800,7 @@ func TestParseWith_oneCfgIsNotArrayButOptsAreMultiple(t *testing.T) {
 }
 
 func TestParseWith_specifyDefault(t *testing.T) {
-	osArgs := []string{}
+	osArgs := []string{"app"}
 	optCfgs := []cliargs.OptCfg{
 		cliargs.OptCfg{Name: "bar", HasArg: true, Default: []string{"A"}},
 		cliargs.OptCfg{Name: "baz", HasArg: true, IsArray: true, Default: []string{"A"}},
@@ -786,7 +808,7 @@ func TestParseWith_specifyDefault(t *testing.T) {
 
 	cmd, err := cliargs.ParseWith(osArgs, optCfgs)
 	assert.Nil(t, err)
-	assert.Equal(t, cmd.Name, "")
+	assert.Equal(t, cmd.Name, "app")
 	assert.False(t, cmd.HasOpt("foo"))
 	assert.True(t, cmd.HasOpt("bar"))
 	assert.True(t, cmd.HasOpt("baz"))
@@ -803,7 +825,7 @@ func TestParseWith_oneCfgHasNoArgButHasDefault(t *testing.T) {
 		cliargs.OptCfg{Name: "foo-bar", HasArg: false, Default: []string{"A"}},
 	}
 
-	osArgs := []string{}
+	osArgs := []string{"app"}
 
 	cmd, err := cliargs.ParseWith(osArgs, optCfgs)
 	assert.NotNil(t, err)
@@ -814,7 +836,7 @@ func TestParseWith_oneCfgHasNoArgButHasDefault(t *testing.T) {
 	default:
 		assert.Fail(t, err.Error())
 	}
-	assert.Equal(t, cmd.Name, "")
+	assert.Equal(t, cmd.Name, "app")
 	assert.False(t, cmd.HasOpt("foo-bar"))
 	assert.Equal(t, cmd.OptArg("foo-bar"), "")
 	assert.Equal(t, cmd.OptArgs("foo-bar"), []string(nil))

--- a/parse_test.go
+++ b/parse_test.go
@@ -534,7 +534,7 @@ func TestParse_multipleArgs(t *testing.T) {
 func TestParse_parseAllArgsEvenIfError(t *testing.T) {
 	defer resetOsArgs()
 
-	os.Args = []string{"/path/to/app", "--foo", "--1", "--bar", "--2", "baz"}
+	os.Args = []string{"/path/to/app", "--foo", "--1", "-b2ar", "--3", "baz"}
 
 	cmd, err := cliargs.Parse()
 
@@ -547,8 +547,11 @@ func TestParse_parseAllArgsEvenIfError(t *testing.T) {
 
 	assert.Equal(t, cmd.Name, "app")
 	assert.True(t, cmd.HasOpt("foo"))
-	assert.True(t, cmd.HasOpt("bar"))
+	assert.True(t, cmd.HasOpt("b"))
+	assert.True(t, cmd.HasOpt("a"))
+	assert.True(t, cmd.HasOpt("r"))
 	assert.False(t, cmd.HasOpt("1"))
 	assert.False(t, cmd.HasOpt("2"))
+	assert.False(t, cmd.HasOpt("3"))
 	assert.Equal(t, cmd.Args(), []string{"baz"})
 }

--- a/parse_test.go
+++ b/parse_test.go
@@ -322,17 +322,17 @@ func TestParse_illegalLongOptIfIncludingInvalidChar(t *testing.T) {
 	default:
 		assert.Fail(t, err.Error())
 	}
-	assert.Equal(t, cmd.Name, "")
+	assert.Equal(t, cmd.Name, "app")
 	assert.Equal(t, cmd.Args(), []string{})
-	assert.False(t, cmd.HasOpt("a"))
+	assert.True(t, cmd.HasOpt("a"))
 	assert.Equal(t, cmd.OptArg("a"), "")
-	assert.Equal(t, cmd.OptArgs("a"), []string(nil))
+	assert.Equal(t, cmd.OptArgs("a"), []string{})
 	assert.False(t, cmd.HasOpt("alphabet"))
 	assert.Equal(t, cmd.OptArg("alphabet"), "")
 	assert.Equal(t, cmd.OptArgs("alphabet"), []string(nil))
-	assert.False(t, cmd.HasOpt("s"))
+	assert.True(t, cmd.HasOpt("s"))
 	assert.Equal(t, cmd.OptArg("s"), "")
-	assert.Equal(t, cmd.OptArgs("s"), []string(nil))
+	assert.Equal(t, cmd.OptArgs("s"), []string{})
 	assert.False(t, cmd.HasOpt("silent"))
 	assert.Equal(t, cmd.OptArg("silent"), "")
 	assert.Equal(t, cmd.OptArgs("silent"), []string(nil))
@@ -355,7 +355,7 @@ func TestParse_illegalLongOptIfFirstCharIsNumber(t *testing.T) {
 	default:
 		assert.Fail(t, err.Error())
 	}
-	assert.Equal(t, cmd.Name, "")
+	assert.Equal(t, cmd.Name, "app")
 	assert.Equal(t, cmd.Args(), []string{})
 	assert.False(t, cmd.HasOpt("a"))
 	assert.Equal(t, cmd.OptArg("a"), "")
@@ -388,7 +388,7 @@ func TestParse_illegalLongOptIfFirstCharIsHyphen(t *testing.T) {
 	default:
 		assert.Fail(t, err.Error())
 	}
-	assert.Equal(t, cmd.Name, "")
+	assert.Equal(t, cmd.Name, "app")
 	assert.Equal(t, cmd.Args(), []string{})
 	assert.False(t, cmd.HasOpt("a"))
 	assert.Equal(t, cmd.OptArg("a"), "")
@@ -423,17 +423,17 @@ func TestParse_IllegalCharInShortOpt(t *testing.T) {
 	default:
 		assert.Fail(t, err.Error())
 	}
-	assert.Equal(t, cmd.Name, "")
+	assert.Equal(t, cmd.Name, "app")
 	assert.Equal(t, cmd.Args(), []string{})
 	assert.False(t, cmd.HasOpt("a"))
 	assert.Equal(t, cmd.OptArg("a"), "")
 	assert.Equal(t, cmd.OptArgs("a"), []string(nil))
-	assert.False(t, cmd.HasOpt("alphabet"))
+	assert.True(t, cmd.HasOpt("alphabet"))
 	assert.Equal(t, cmd.OptArg("alphabet"), "")
-	assert.Equal(t, cmd.OptArgs("alphabet"), []string(nil))
-	assert.False(t, cmd.HasOpt("s"))
+	assert.Equal(t, cmd.OptArgs("alphabet"), []string{})
+	assert.True(t, cmd.HasOpt("s"))
 	assert.Equal(t, cmd.OptArg("s"), "")
-	assert.Equal(t, cmd.OptArgs("s"), []string(nil))
+	assert.Equal(t, cmd.OptArgs("s"), []string{})
 	assert.False(t, cmd.HasOpt("silent"))
 	assert.Equal(t, cmd.OptArg("silent"), "")
 	assert.Equal(t, cmd.OptArgs("silent"), []string(nil))
@@ -529,4 +529,26 @@ func TestParse_multipleArgs(t *testing.T) {
 	assert.Equal(t, cmd.OptArg("baz"), "")
 	assert.Equal(t, cmd.OptArgs("baz"), []string{})
 	assert.Equal(t, cmd.Args(), []string{"qux", "quux"})
+}
+
+func TestParse_parseAllArgsEvenIfError(t *testing.T) {
+	defer resetOsArgs()
+
+	os.Args = []string{"/path/to/app", "--foo", "--1", "--bar", "--2", "baz"}
+
+	cmd, err := cliargs.Parse()
+
+	switch casted := err.(type) {
+	case cliargs.OptionHasInvalidChar:
+		assert.Equal(t, casted.Option, "1")
+	default:
+		assert.Fail(t, err.Error())
+	}
+
+	assert.Equal(t, cmd.Name, "app")
+	assert.True(t, cmd.HasOpt("foo"))
+	assert.True(t, cmd.HasOpt("bar"))
+	assert.False(t, cmd.HasOpt("1"))
+	assert.False(t, cmd.HasOpt("2"))
+	assert.Equal(t, cmd.Args(), []string{"baz"})
 }


### PR DESCRIPTION
This PR modifies this library to parse all arguments even if there are errors. 
This modification is to enable to ignore errors if there is either `--version` or `--help` arguments.

Because the proposal of #38 couldn't retrieve an option caused an error, I adopted the solution of this PR.

Closes #38 