### PR TITLE
cicd: added go version 1.21 to ci targets, upgrade github actions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -12,13 +12,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        gover: ['~1.18', '~1.19', '~1.20']
+        gover: ['~1.18', '~1.19', '~1.20', '~1.21']
         os: [ubuntu-latest, windows-latest, macos-latest]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - name: Set up Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v4
       with:
         go-version: ${{ matrix.gover }}
 


### PR DESCRIPTION
T/O.