### PR TITLE
chore,update: upgraded dependencies

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,8 @@ module github.com/sttk/cliargs
 go 1.18
 
 require (
-	github.com/stretchr/testify v1.8.4
-	github.com/sttk/linebreak v0.3.0
+	github.com/stretchr/testify v1.9.0
+	github.com/sttk/linebreak v0.4.1
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -2,10 +2,10 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
-github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
-github.com/sttk/linebreak v0.3.0 h1:JrymoRg/oyOF2+zegT6cjbSQJleMLtfyeroWZ63DRz4=
-github.com/sttk/linebreak v0.3.0/go.mod h1:+lTR3A9FoGj0r/q9k2sDNTqotHyQ6mNMa6T3zyqw7Ro=
+github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
+github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+github.com/sttk/linebreak v0.4.1 h1:9+2wPiqHiH8tiouJ1HAMBCRXyfm3Fk1SRHY5sPFimuU=
+github.com/sttk/linebreak v0.4.1/go.mod h1:+lTR3A9FoGj0r/q9k2sDNTqotHyQ6mNMa6T3zyqw7Ro=
 golang.org/x/sys v0.12.0 h1:CM0HF96J0hcLAwsHPJZjfdNzs0gftsLfgKt57wWHJ0o=
 golang.org/x/sys v0.12.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.12.0 h1:/ZfYdc3zq+q02Rv9vGqTeSItdzZTSNDmfTi0mBAuidU=

--- a/print-help.go
+++ b/print-help.go
@@ -6,6 +6,7 @@ package cliargs
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/sttk/linebreak"
 )
@@ -42,7 +43,7 @@ func (help Help) Iter() HelpIter {
 		return HelpIter{}
 	}
 
-	lineWidth := linebreak.TermWidth()
+	lineWidth := linebreak.TermCols()
 
 	return HelpIter{
 		lineWidth: lineWidth,
@@ -93,7 +94,7 @@ func newBlockIter(b block, lineWidth int) blockIter {
 	return blockIter{
 		texts:    b.texts,
 		indent:   b.indent,
-		margin:   linebreak.Spaces(b.marginLeft),
+		margin:   strings.Repeat(" ", b.marginLeft),
 		lineIter: linebreak.New(b.texts[0], printWidth),
 	}
 }
@@ -117,7 +118,7 @@ func (iter *blockIter) next() (string, bool) {
 		return line, true
 	}
 
-	iter.lineIter.SetIndent(linebreak.Spaces(iter.indent))
+	iter.lineIter.SetIndent(strings.Repeat(" ", iter.indent))
 	return line, more
 }
 
@@ -192,9 +193,9 @@ func (help *Help) AddOpts(optCfgs []OptCfg, wrapOpts ...int) {
 			texts[i] = makeOptTitle(cfg)
 			width := linebreak.TextWidth(texts[i])
 			if width+2 > b.indent {
-				texts[i] += "\n" + linebreak.Spaces(b.indent) + cfg.Desc
+				texts[i] += "\n" + strings.Repeat(" ", b.indent) + cfg.Desc
 			} else {
-				texts[i] += linebreak.Spaces(b.indent-width) + cfg.Desc
+				texts[i] += strings.Repeat(" ", b.indent-width) + cfg.Desc
 			}
 			i++
 		}
@@ -226,7 +227,7 @@ func (help *Help) AddOpts(optCfgs []OptCfg, wrapOpts ...int) {
 			if cfg.Name == anyOption {
 				continue
 			}
-			texts[i] += linebreak.Spaces(indent-widths[i]) + cfg.Desc
+			texts[i] += strings.Repeat(" ", indent-widths[i]) + cfg.Desc
 			i++
 		}
 	}


### PR DESCRIPTION
This PR upgrade  the dependencies: `linebreak` and `testify`.

- `linebreak` : `v0.3.0` → `v0.4.1`
- `testify` : `v1.8.4` → `v1.9.0`