### PR TITLE
fix!: modified struct name of an error

### DIFF
--- a/errors/errors.go
+++ b/errors/errors.go
@@ -18,19 +18,19 @@ type InvalidOption interface {
 	Error() string
 }
 
-// OptionHasInvalidChar is the error which indicates that an invalid character
+// OptionContainsInvalidChar is the error which indicates that an invalid character
 // is found in the option.
-type OptionHasInvalidChar struct {
+type OptionContainsInvalidChar struct {
 	Option string
 }
 
 // Error is the method to retrieve the message of this error.
-func (e OptionHasInvalidChar) Error() string {
-	return fmt.Sprintf("OptionHasInvalidChar{Option:%s}", e.Option)
+func (e OptionContainsInvalidChar) Error() string {
+	return fmt.Sprintf("OptionContainsInvalidChar{Option:%s}", e.Option)
 }
 
 // GetOption is the method to retrieve the name of the option that caused this error.
-func (e OptionHasInvalidChar) GetOption() string {
+func (e OptionContainsInvalidChar) GetOption() string {
 	return e.Option
 }
 

--- a/errors/errors_test.go
+++ b/errors/errors_test.go
@@ -9,11 +9,11 @@ import (
 	"github.com/sttk/cliargs/errors"
 )
 
-func TestErrors_OptionHasInvalidChar(t *testing.T) {
-	e := errors.OptionHasInvalidChar{Option: "foo"}
+func TestErrors_OptionContainsInvalidChar(t *testing.T) {
+	e := errors.OptionContainsInvalidChar{Option: "foo"}
 	assert.Equal(t, e.Option, "foo")
 	assert.Equal(t, e.GetOption(), "foo")
-	assert.Equal(t, e.Error(), "OptionHasInvalidChar{Option:foo}")
+	assert.Equal(t, e.Error(), "OptionContainsInvalidChar{Option:foo}")
 
 	var ee errors.InvalidOption = e
 	assert.Equal(t, ee.GetOption(), "foo")

--- a/parse.go
+++ b/parse.go
@@ -147,14 +147,14 @@ L0:
 					}
 					if !unicode.Is(rangeOfAlNumMarks, r) {
 						if firstErr == nil {
-							firstErr = errors.OptionHasInvalidChar{Option: arg}
+							firstErr = errors.OptionContainsInvalidChar{Option: arg}
 						}
 						continue L0
 					}
 				} else {
 					if !unicode.Is(rangeOfAlphabets, r) {
 						if firstErr == nil {
-							firstErr = errors.OptionHasInvalidChar{Option: arg}
+							firstErr = errors.OptionContainsInvalidChar{Option: arg}
 						}
 						continue L0
 					}
@@ -213,7 +213,7 @@ L0:
 				}
 				if !unicode.Is(rangeOfAlphabets, r) {
 					if firstErr == nil {
-						firstErr = errors.OptionHasInvalidChar{Option: string(r)}
+						firstErr = errors.OptionContainsInvalidChar{Option: string(r)}
 					}
 					name = ""
 				} else {

--- a/parse_test.go
+++ b/parse_test.go
@@ -328,9 +328,9 @@ func TestParse_illegalLongOptIfIncludingInvalidChar(t *testing.T) {
 	err := cmd.Parse()
 
 	assert.NotNil(t, err)
-	assert.Equal(t, err.Error(), "OptionHasInvalidChar{Option:abc%def}")
+	assert.Equal(t, err.Error(), "OptionContainsInvalidChar{Option:abc%def}")
 	switch e := err.(type) {
-	case errors.OptionHasInvalidChar:
+	case errors.OptionContainsInvalidChar:
 		assert.Equal(t, e.Option, "abc%def")
 	default:
 		assert.Fail(t, err.Error())
@@ -369,9 +369,9 @@ func TestParse_illegalLongOptIfFirstCharIsNumber(t *testing.T) {
 	err := cmd.Parse()
 
 	assert.NotNil(t, err)
-	assert.Equal(t, err.Error(), "OptionHasInvalidChar{Option:1abc}")
+	assert.Equal(t, err.Error(), "OptionContainsInvalidChar{Option:1abc}")
 	switch e := err.(type) {
-	case errors.OptionHasInvalidChar:
+	case errors.OptionContainsInvalidChar:
 		assert.Equal(t, e.Option, "1abc")
 	default:
 		assert.Fail(t, err.Error())
@@ -410,9 +410,9 @@ func TestParse_illegalLongOptIfFirstCharIsHyphen(t *testing.T) {
 	err := cmd.Parse()
 
 	assert.NotNil(t, err)
-	assert.Equal(t, err.Error(), "OptionHasInvalidChar{Option:-aaa=123}")
+	assert.Equal(t, err.Error(), "OptionContainsInvalidChar{Option:-aaa=123}")
 	switch e := err.(type) {
-	case errors.OptionHasInvalidChar:
+	case errors.OptionContainsInvalidChar:
 		assert.Equal(t, e.Option, "-aaa=123")
 	default:
 		assert.Fail(t, err.Error())
@@ -453,9 +453,9 @@ func TestParse_IllegalCharInShortOpt(t *testing.T) {
 	err := cmd.Parse()
 
 	assert.NotNil(t, err)
-	assert.Equal(t, err.Error(), "OptionHasInvalidChar{Option:@}")
+	assert.Equal(t, err.Error(), "OptionContainsInvalidChar{Option:@}")
 	switch e := err.(type) {
-	case errors.OptionHasInvalidChar:
+	case errors.OptionContainsInvalidChar:
 		assert.Equal(t, e.Option, "@")
 	default:
 		assert.Fail(t, err.Error())
@@ -587,7 +587,7 @@ func TestParse_parseAllArgsEvenIfError(t *testing.T) {
 	err := cmd.Parse()
 
 	switch e := err.(type) {
-	case errors.OptionHasInvalidChar:
+	case errors.OptionContainsInvalidChar:
 		assert.Equal(t, e.Option, "1")
 	default:
 		assert.Fail(t, err.Error())


### PR DESCRIPTION
This PR renames an error: `OptionHasInvalidChar` -> `OptionContainsInvalidChar`.

This rename was supposed to be fixed in the previous PR #54, but I forgot to include it.