### PR TITLE
update!: moved all program elements in sub packages to root

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -2,9 +2,7 @@
 // This program is free software under MIT License.
 // See the file LICENSE in this distribution for more details.
 
-// Package errors contains the error structures that can occur during
-// command line argument parsing.
-package errors
+package cliargs
 
 import (
 	"fmt"

--- a/errors_test.go
+++ b/errors_test.go
@@ -1,4 +1,4 @@
-package errors_test
+package cliargs_test
 
 import (
 	"fmt"
@@ -6,112 +6,112 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/sttk/cliargs/errors"
+	"github.com/sttk/cliargs"
 )
 
 func TestErrors_OptionContainsInvalidChar(t *testing.T) {
-	e := errors.OptionContainsInvalidChar{Option: "foo"}
+	e := cliargs.OptionContainsInvalidChar{Option: "foo"}
 	assert.Equal(t, e.Option, "foo")
 	assert.Equal(t, e.GetOption(), "foo")
 	assert.Equal(t, e.Error(), "OptionContainsInvalidChar{Option:foo}")
 
-	var ee errors.InvalidOption = e
+	var ee cliargs.InvalidOption = e
 	assert.Equal(t, ee.GetOption(), "foo")
 }
 
 func TestErrors_UnconfiguredOption(t *testing.T) {
-	e := errors.UnconfiguredOption{Option: "foo"}
+	e := cliargs.UnconfiguredOption{Option: "foo"}
 	assert.Equal(t, e.Option, "foo")
 	assert.Equal(t, e.GetOption(), "foo")
 	assert.Equal(t, e.Error(), "UnconfiguredOption{Option:foo}")
 
-	var ee errors.InvalidOption = e
+	var ee cliargs.InvalidOption = e
 	assert.Equal(t, ee.GetOption(), "foo")
 }
 
 func TestErrors_OptionNeedsArg(t *testing.T) {
-	e := errors.OptionNeedsArg{Option: "foo", StoreKey: "Foo"}
+	e := cliargs.OptionNeedsArg{Option: "foo", StoreKey: "Foo"}
 	assert.Equal(t, e.Option, "foo")
 	assert.Equal(t, e.StoreKey, "Foo")
 	assert.Equal(t, e.GetOption(), "foo")
 	assert.Equal(t, e.Error(), "OptionNeedsArg{Option:foo,StoreKey:Foo}")
 
-	var ee errors.InvalidOption = e
+	var ee cliargs.InvalidOption = e
 	assert.Equal(t, ee.GetOption(), "foo")
 }
 
 func TestErrors_OptionTakesNoArg(t *testing.T) {
-	e := errors.OptionTakesNoArg{Option: "foo", StoreKey: "Foo"}
+	e := cliargs.OptionTakesNoArg{Option: "foo", StoreKey: "Foo"}
 	assert.Equal(t, e.Option, "foo")
 	assert.Equal(t, e.StoreKey, "Foo")
 	assert.Equal(t, e.GetOption(), "foo")
 	assert.Equal(t, e.Error(), "OptionTakesNoArg{Option:foo,StoreKey:Foo}")
 
-	var ee errors.InvalidOption = e
+	var ee cliargs.InvalidOption = e
 	assert.Equal(t, ee.GetOption(), "foo")
 }
 
 func TestErrors_OptionIsNotArray(t *testing.T) {
-	e := errors.OptionIsNotArray{Option: "foo", StoreKey: "Foo"}
+	e := cliargs.OptionIsNotArray{Option: "foo", StoreKey: "Foo"}
 	assert.Equal(t, e.Option, "foo")
 	assert.Equal(t, e.StoreKey, "Foo")
 	assert.Equal(t, e.GetOption(), "foo")
 	assert.Equal(t, e.Error(), "OptionIsNotArray{Option:foo,StoreKey:Foo}")
 
-	var ee errors.InvalidOption = e
+	var ee cliargs.InvalidOption = e
 	assert.Equal(t, ee.GetOption(), "foo")
 }
 
 func TestErrors_StoreKeyIsDuplicated(t *testing.T) {
-	e := errors.StoreKeyIsDuplicated{StoreKey: "Foo", Name: "foo"}
+	e := cliargs.StoreKeyIsDuplicated{StoreKey: "Foo", Name: "foo"}
 
 	assert.Equal(t, e.Name, "foo")
 	assert.Equal(t, e.StoreKey, "Foo")
 	assert.Equal(t, e.GetOption(), "foo")
 	assert.Equal(t, e.Error(), "StoreKeyIsDuplicated{StoreKey:Foo,Name:foo}")
 
-	var ee errors.InvalidOption = e
+	var ee cliargs.InvalidOption = e
 	assert.Equal(t, ee.GetOption(), "foo")
 }
 
 func TestErrors_ConfigIsArrayButHasNoArg(t *testing.T) {
-	e := errors.ConfigIsArrayButHasNoArg{StoreKey: "Foo", Name: "foo"}
+	e := cliargs.ConfigIsArrayButHasNoArg{StoreKey: "Foo", Name: "foo"}
 
 	assert.Equal(t, e.Name, "foo")
 	assert.Equal(t, e.StoreKey, "Foo")
 	assert.Equal(t, e.GetOption(), "foo")
 	assert.Equal(t, e.Error(), "ConfigIsArrayButHasNoArg{StoreKey:Foo,Name:foo}")
 
-	var ee errors.InvalidOption = e
+	var ee cliargs.InvalidOption = e
 	assert.Equal(t, ee.GetOption(), "foo")
 }
 
 func TestErrors_ConfigHasDefaultsButHasNoArg(t *testing.T) {
-	e := errors.ConfigHasDefaultsButHasNoArg{StoreKey: "Foo", Name: "foo"}
+	e := cliargs.ConfigHasDefaultsButHasNoArg{StoreKey: "Foo", Name: "foo"}
 
 	assert.Equal(t, e.Name, "foo")
 	assert.Equal(t, e.StoreKey, "Foo")
 	assert.Equal(t, e.GetOption(), "foo")
 	assert.Equal(t, e.Error(), "ConfigHasDefaultsButHasNoArg{StoreKey:Foo,Name:foo}")
 
-	var ee errors.InvalidOption = e
+	var ee cliargs.InvalidOption = e
 	assert.Equal(t, ee.GetOption(), "foo")
 }
 
 func TestErrors_OptionNameIsDuplicated(t *testing.T) {
-	e := errors.OptionNameIsDuplicated{StoreKey: "Foo", Name: "foo"}
+	e := cliargs.OptionNameIsDuplicated{StoreKey: "Foo", Name: "foo"}
 
 	assert.Equal(t, e.Name, "foo")
 	assert.Equal(t, e.StoreKey, "Foo")
 	assert.Equal(t, e.GetOption(), "foo")
 	assert.Equal(t, e.Error(), "OptionNameIsDuplicated{StoreKey:Foo,Name:foo}")
 
-	var ee errors.InvalidOption = e
+	var ee cliargs.InvalidOption = e
 	assert.Equal(t, ee.GetOption(), "foo")
 }
 
 func TestErrors_OptionArgIsInvalid(t *testing.T) {
-	e := errors.OptionArgIsInvalid{
+	e := cliargs.OptionArgIsInvalid{
 		StoreKey: "Foo", Option: "foo", OptArg: "xx", TypeKind: reflect.Int,
 		Cause: fmt.Errorf("type error")}
 
@@ -122,16 +122,16 @@ func TestErrors_OptionArgIsInvalid(t *testing.T) {
 	assert.Equal(t, e.GetOption(), "foo")
 	assert.Equal(t, e.Error(), "OptionArgIsInvalid{StoreKey:Foo,Option:foo,OptArg:xx,TypeKind:int,Cause:type error}")
 
-	var ee errors.InvalidOption = e
+	var ee cliargs.InvalidOption = e
 	assert.Equal(t, ee.GetOption(), "foo")
 }
 
 func TestErrors_OptionStoreIsNotChangeable(t *testing.T) {
-	e := errors.OptionStoreIsNotChangeable{}
+	e := cliargs.OptionStoreIsNotChangeable{}
 	assert.Equal(t, e.Error(), "OptionStoreIsNotChangeable{}")
 }
 
 func TestErrors_BadFieldType(t *testing.T) {
-	e := errors.BadFieldType{Option: "foo", Field: "Foo", Type: reflect.TypeOf(0)}
+	e := cliargs.BadFieldType{Option: "foo", Field: "Foo", Type: reflect.TypeOf(0)}
 	assert.Equal(t, e.Error(), "BadFieldType{Option:foo,Field:Foo,Type:int}")
 }

--- a/example_errors_test.go
+++ b/example_errors_test.go
@@ -1,15 +1,15 @@
-package errors_test
+package cliargs_test
 
 import (
-	goerrors "errors"
+	"errors"
 	"fmt"
 	"reflect"
 
-	"github.com/sttk/cliargs/errors"
+	"github.com/sttk/cliargs"
 )
 
 func ExampleBadFieldType_Error() {
-	e := errors.BadFieldType{
+	e := cliargs.BadFieldType{
 		Option: "foo-bar",
 		Field:  "FooBar",
 		Type:   reflect.TypeOf(int(0)),
@@ -21,7 +21,7 @@ func ExampleBadFieldType_Error() {
 }
 
 func ExampleConfigHasDefaultsButHasNoArg_Error() {
-	e := errors.ConfigHasDefaultsButHasNoArg{
+	e := cliargs.ConfigHasDefaultsButHasNoArg{
 		StoreKey: "FooBar",
 		Name:     "foo-bar",
 	}
@@ -32,11 +32,11 @@ func ExampleConfigHasDefaultsButHasNoArg_Error() {
 }
 
 func ExampleConfigHasDefaultsButHasNoArg_GetOption() {
-	e := errors.ConfigHasDefaultsButHasNoArg{
+	e := cliargs.ConfigHasDefaultsButHasNoArg{
 		StoreKey: "FooBar",
 		Name:     "foo-bar",
 	}
-	var ee errors.InvalidOption = e
+	var ee cliargs.InvalidOption = e
 
 	fmt.Printf("%s\n", e.GetOption())
 	fmt.Printf("%s\n", ee.GetOption())
@@ -46,7 +46,7 @@ func ExampleConfigHasDefaultsButHasNoArg_GetOption() {
 }
 
 func ExampleConfigIsArrayButHasNoArg_Error() {
-	e := errors.ConfigIsArrayButHasNoArg{
+	e := cliargs.ConfigIsArrayButHasNoArg{
 		StoreKey: "FooBar",
 		Name:     "foo-bar",
 	}
@@ -57,11 +57,11 @@ func ExampleConfigIsArrayButHasNoArg_Error() {
 }
 
 func ExampleConfigIsArrayButHasNoArg_GetOption() {
-	e := errors.ConfigIsArrayButHasNoArg{
+	e := cliargs.ConfigIsArrayButHasNoArg{
 		StoreKey: "FooBar",
 		Name:     "foo-bar",
 	}
-	var ee errors.InvalidOption = e
+	var ee cliargs.InvalidOption = e
 
 	fmt.Printf("%s\n", e.GetOption())
 	fmt.Printf("%s\n", ee.GetOption())
@@ -71,7 +71,7 @@ func ExampleConfigIsArrayButHasNoArg_GetOption() {
 }
 
 func ExampleOptionArgIsInvalid_Error() {
-	e := errors.OptionArgIsInvalid{
+	e := cliargs.OptionArgIsInvalid{
 		StoreKey: "FooBar",
 		Option:   "foo-bar",
 		OptArg:   "123",
@@ -85,14 +85,14 @@ func ExampleOptionArgIsInvalid_Error() {
 }
 
 func ExampleOptionArgIsInvalid_GetOption() {
-	e := errors.OptionArgIsInvalid{
+	e := cliargs.OptionArgIsInvalid{
 		StoreKey: "FooBar",
 		Option:   "foo-bar",
 		OptArg:   "123",
 		TypeKind: reflect.Int,
 		Cause:    fmt.Errorf("Bad number format"),
 	}
-	var ee errors.InvalidOption = e
+	var ee cliargs.InvalidOption = e
 
 	fmt.Printf("%s\n", e.GetOption())
 	fmt.Printf("%s\n", ee.GetOption())
@@ -102,11 +102,9 @@ func ExampleOptionArgIsInvalid_GetOption() {
 }
 
 func ExampleOptionArgIsInvalid_Unwrap() {
-	// import ( goerrors "errors" )
-
 	e0 := fmt.Errorf("Bad number format")
 
-	e := errors.OptionArgIsInvalid{
+	e := cliargs.OptionArgIsInvalid{
 		StoreKey: "FooBar",
 		Option:   "foo-bar",
 		OptArg:   "123",
@@ -114,13 +112,13 @@ func ExampleOptionArgIsInvalid_Unwrap() {
 		Cause:    e0,
 	}
 
-	fmt.Printf("%t\n", goerrors.Is(e, e0))
+	fmt.Printf("%t\n", errors.Is(e, e0))
 	// Output:
 	// true
 }
 
 func ExampleOptionIsNotArray_Error() {
-	e := errors.OptionIsNotArray{
+	e := cliargs.OptionIsNotArray{
 		Option:   "foo-bar",
 		StoreKey: "FooBar",
 	}
@@ -131,11 +129,11 @@ func ExampleOptionIsNotArray_Error() {
 }
 
 func ExampleOptionIsNotArray_GetOption() {
-	e := errors.OptionIsNotArray{
+	e := cliargs.OptionIsNotArray{
 		Option:   "foo-bar",
 		StoreKey: "FooBar",
 	}
-	var ee errors.InvalidOption = e
+	var ee cliargs.InvalidOption = e
 
 	fmt.Printf("%s\n", e.GetOption())
 	fmt.Printf("%s\n", ee.GetOption())
@@ -145,7 +143,7 @@ func ExampleOptionIsNotArray_GetOption() {
 }
 
 func ExampleOptionNameIsDuplicated_Error() {
-	e := errors.OptionNameIsDuplicated{
+	e := cliargs.OptionNameIsDuplicated{
 		StoreKey: "FooBar",
 		Name:     "foo-bar",
 	}
@@ -156,12 +154,12 @@ func ExampleOptionNameIsDuplicated_Error() {
 }
 
 func ExampleOptionNameIsDuplicated_GetOption() {
-	e := errors.OptionNameIsDuplicated{
+	e := cliargs.OptionNameIsDuplicated{
 		StoreKey: "FooBar",
 		Name:     "foo-bar",
 	}
 
-	var ee errors.InvalidOption = e
+	var ee cliargs.InvalidOption = e
 
 	fmt.Printf("%s\n", e.GetOption())
 	fmt.Printf("%s\n", ee.GetOption())
@@ -171,7 +169,7 @@ func ExampleOptionNameIsDuplicated_GetOption() {
 }
 
 func ExampleOptionNeedsArg_Error() {
-	e := errors.OptionNeedsArg{
+	e := cliargs.OptionNeedsArg{
 		StoreKey: "FooBar",
 		Option:   "foo-bar",
 	}
@@ -182,12 +180,12 @@ func ExampleOptionNeedsArg_Error() {
 }
 
 func ExampleOptionNeedsArg_GetOption() {
-	e := errors.OptionNeedsArg{
+	e := cliargs.OptionNeedsArg{
 		Option:   "foo-bar",
 		StoreKey: "FooBar",
 	}
 
-	var ee errors.InvalidOption = e
+	var ee cliargs.InvalidOption = e
 
 	fmt.Printf("%s\n", e.GetOption())
 	fmt.Printf("%s\n", ee.GetOption())
@@ -197,7 +195,7 @@ func ExampleOptionNeedsArg_GetOption() {
 }
 
 func ExampleOptionStoreIsNotChangeable_Error() {
-	e := errors.OptionStoreIsNotChangeable{}
+	e := cliargs.OptionStoreIsNotChangeable{}
 
 	fmt.Printf("%s\n", e.Error())
 	// Output:
@@ -205,7 +203,7 @@ func ExampleOptionStoreIsNotChangeable_Error() {
 }
 
 func ExampleOptionTakesNoArg_Error() {
-	e := errors.OptionTakesNoArg{
+	e := cliargs.OptionTakesNoArg{
 		Option:   "foo-bar",
 		StoreKey: "FooBar",
 	}
@@ -216,12 +214,12 @@ func ExampleOptionTakesNoArg_Error() {
 }
 
 func ExampleOptionTakesNoArg_GetOption() {
-	e := errors.OptionTakesNoArg{
+	e := cliargs.OptionTakesNoArg{
 		Option:   "foo-bar",
 		StoreKey: "FooBar",
 	}
 
-	var ee errors.InvalidOption = e
+	var ee cliargs.InvalidOption = e
 
 	fmt.Printf("%s\n", e.GetOption())
 	fmt.Printf("%s\n", ee.GetOption())
@@ -231,7 +229,7 @@ func ExampleOptionTakesNoArg_GetOption() {
 }
 
 func ExampleStoreKeyIsDuplicated_Error() {
-	e := errors.StoreKeyIsDuplicated{
+	e := cliargs.StoreKeyIsDuplicated{
 		StoreKey: "FooBar",
 		Name:     "foo-bar",
 	}
@@ -242,12 +240,12 @@ func ExampleStoreKeyIsDuplicated_Error() {
 }
 
 func ExampleStoreKeyIsDuplicated_GetOption() {
-	e := errors.StoreKeyIsDuplicated{
+	e := cliargs.StoreKeyIsDuplicated{
 		StoreKey: "FooBar",
 		Name:     "foo-bar",
 	}
 
-	var ee errors.InvalidOption = e
+	var ee cliargs.InvalidOption = e
 
 	fmt.Printf("%s\n", e.GetOption())
 	fmt.Printf("%s\n", ee.GetOption())
@@ -257,7 +255,7 @@ func ExampleStoreKeyIsDuplicated_GetOption() {
 }
 
 func ExampleUnconfiguredOption_Error() {
-	e := errors.UnconfiguredOption{
+	e := cliargs.UnconfiguredOption{
 		Option: "foo-bar",
 	}
 
@@ -267,11 +265,11 @@ func ExampleUnconfiguredOption_Error() {
 }
 
 func ExampleUnconfiguredOption_GetOption() {
-	e := errors.UnconfiguredOption{
+	e := cliargs.UnconfiguredOption{
 		Option: "foo-bar",
 	}
 
-	var ee errors.InvalidOption = e
+	var ee cliargs.InvalidOption = e
 
 	fmt.Printf("%s\n", e.GetOption())
 	fmt.Printf("%s\n", ee.GetOption())

--- a/parse-for.go
+++ b/parse-for.go
@@ -8,8 +8,6 @@ import (
 	"reflect"
 	"strconv"
 	"strings"
-
-	"github.com/sttk/cliargs/errors"
 )
 
 // ParseFor is the method to parse command line arguments and set their values to the option store
@@ -88,7 +86,7 @@ func (cmd *Cmd) ParseUntilSubCmdFor(optStore any) (Cmd, error) {
 func MakeOptCfgsFor(options any) ([]OptCfg, error) {
 	v := reflect.ValueOf(options)
 	if v.Kind() != reflect.Ptr {
-		return nil, errors.OptionStoreIsNotChangeable{}
+		return nil, OptionStoreIsNotChangeable{}
 	}
 	v = v.Elem()
 
@@ -255,7 +253,7 @@ func newValueSetter(
 func newBadFieldTypeError(
 	optName string, fldName string, t reflect.Type,
 ) (func([]string) error, error) {
-	e := errors.BadFieldType{Option: optName, Field: fldName, Type: t}
+	e := BadFieldType{Option: optName, Field: fldName, Type: t}
 	return nil, e
 }
 
@@ -278,7 +276,7 @@ func newIntSetter(
 		}
 		n, e := strconv.ParseInt(s[0], 0, bitSize)
 		if e != nil {
-			return errors.OptionArgIsInvalid{
+			return OptionArgIsInvalid{
 				Option: optName, StoreKey: fldName, OptArg: s[0], TypeKind: fld.Type().Kind(), Cause: e}
 		}
 		fld.SetInt(n)
@@ -296,7 +294,7 @@ func newUintSetter(
 		}
 		n, e := strconv.ParseUint(s[0], 0, bitSize)
 		if e != nil {
-			return errors.OptionArgIsInvalid{
+			return OptionArgIsInvalid{
 				Option: optName, StoreKey: fldName, OptArg: s[0], TypeKind: fld.Type().Kind(), Cause: e}
 		}
 		fld.SetUint(n)
@@ -314,7 +312,7 @@ func newFloatSetter(
 		}
 		n, e := strconv.ParseFloat(s[0], bitSize)
 		if e != nil {
-			return errors.OptionArgIsInvalid{
+			return OptionArgIsInvalid{
 				Option: optName, StoreKey: fldName, OptArg: s[0], TypeKind: fld.Type().Kind(), Cause: e}
 		}
 		fld.SetFloat(n)
@@ -354,7 +352,7 @@ func newIntArraySetter(
 		for i := 0; i < n; i++ {
 			v, e := strconv.ParseInt(s[i], 0, bitSize)
 			if e != nil {
-				return errors.OptionArgIsInvalid{
+				return OptionArgIsInvalid{
 					Option: optName, StoreKey: fldName, OptArg: s[i], TypeKind: t.Kind(), Cause: e}
 			}
 			a[i] = reflect.ValueOf(v).Convert(t)
@@ -383,7 +381,7 @@ func newUintArraySetter(
 		for i := 0; i < n; i++ {
 			v, e := strconv.ParseUint(s[i], 0, bitSize)
 			if e != nil {
-				return errors.OptionArgIsInvalid{
+				return OptionArgIsInvalid{
 					Option: optName, StoreKey: fldName, OptArg: s[i], TypeKind: t.Kind(), Cause: e}
 			}
 			a[i] = reflect.ValueOf(v).Convert(t)
@@ -412,7 +410,7 @@ func newFloatArraySetter(
 		for i := 0; i < n; i++ {
 			v, e := strconv.ParseFloat(s[i], bitSize)
 			if e != nil {
-				return errors.OptionArgIsInvalid{
+				return OptionArgIsInvalid{
 					Option: optName, StoreKey: fldName, OptArg: s[i], TypeKind: t.Kind(), Cause: e}
 			}
 			a[i] = reflect.ValueOf(v).Convert(t)

--- a/parse-for_test.go
+++ b/parse-for_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/sttk/cliargs"
-	errs "github.com/sttk/cliargs/errors"
 )
 
 func TestParseFor_emptyOptionStoreAndNoArgs(t *testing.T) {
@@ -1447,11 +1446,11 @@ func TestParseFor_errorEmptyDefaultValueIfOptionIsInt(t *testing.T) {
 	)
 	assert.NotNil(t, errors.Unwrap(err))
 	switch err.(type) {
-	case errs.OptionArgIsInvalid:
-		assert.Equal(t, err.(errs.OptionArgIsInvalid).StoreKey, "IntVar")
-		assert.Equal(t, err.(errs.OptionArgIsInvalid).Option, "int-var")
-		assert.Equal(t, err.(errs.OptionArgIsInvalid).OptArg, "")
-		assert.Equal(t, err.(errs.OptionArgIsInvalid).TypeKind, reflect.Int)
+	case cliargs.OptionArgIsInvalid:
+		assert.Equal(t, err.(cliargs.OptionArgIsInvalid).StoreKey, "IntVar")
+		assert.Equal(t, err.(cliargs.OptionArgIsInvalid).Option, "int-var")
+		assert.Equal(t, err.(cliargs.OptionArgIsInvalid).OptArg, "")
+		assert.Equal(t, err.(cliargs.OptionArgIsInvalid).TypeKind, reflect.Int)
 	default:
 		assert.Fail(t, err.Error())
 	}
@@ -1480,11 +1479,11 @@ func TestParseFor_errorEmptyDefaultValueIfOptionIsUint(t *testing.T) {
 	)
 	assert.NotNil(t, errors.Unwrap(err))
 	switch err.(type) {
-	case errs.OptionArgIsInvalid:
-		assert.Equal(t, err.(errs.OptionArgIsInvalid).StoreKey, "UintVar")
-		assert.Equal(t, err.(errs.OptionArgIsInvalid).Option, "uint-var")
-		assert.Equal(t, err.(errs.OptionArgIsInvalid).OptArg, "")
-		assert.Equal(t, err.(errs.OptionArgIsInvalid).TypeKind, reflect.Uint)
+	case cliargs.OptionArgIsInvalid:
+		assert.Equal(t, err.(cliargs.OptionArgIsInvalid).StoreKey, "UintVar")
+		assert.Equal(t, err.(cliargs.OptionArgIsInvalid).Option, "uint-var")
+		assert.Equal(t, err.(cliargs.OptionArgIsInvalid).OptArg, "")
+		assert.Equal(t, err.(cliargs.OptionArgIsInvalid).TypeKind, reflect.Uint)
 	default:
 		assert.Fail(t, err.Error())
 	}
@@ -1513,11 +1512,11 @@ func TestParseFor_errorEmptyDefaultValueIfOptionIsFloat(t *testing.T) {
 	)
 	assert.NotNil(t, errors.Unwrap(err))
 	switch err.(type) {
-	case errs.OptionArgIsInvalid:
-		assert.Equal(t, err.(errs.OptionArgIsInvalid).StoreKey, "Float64Var")
-		assert.Equal(t, err.(errs.OptionArgIsInvalid).Option, "float-var")
-		assert.Equal(t, err.(errs.OptionArgIsInvalid).OptArg, "")
-		assert.Equal(t, err.(errs.OptionArgIsInvalid).TypeKind, reflect.Float64)
+	case cliargs.OptionArgIsInvalid:
+		assert.Equal(t, err.(cliargs.OptionArgIsInvalid).StoreKey, "Float64Var")
+		assert.Equal(t, err.(cliargs.OptionArgIsInvalid).Option, "float-var")
+		assert.Equal(t, err.(cliargs.OptionArgIsInvalid).OptArg, "")
+		assert.Equal(t, err.(cliargs.OptionArgIsInvalid).TypeKind, reflect.Float64)
 	default:
 		assert.Fail(t, err.Error())
 	}
@@ -1566,11 +1565,11 @@ func TestParseFor_errorEmptyDefaultValueIfOptionIsIntArray(t *testing.T) {
 	)
 	assert.NotNil(t, errors.Unwrap(err))
 	switch err.(type) {
-	case errs.OptionArgIsInvalid:
-		assert.Equal(t, err.(errs.OptionArgIsInvalid).StoreKey, "IntArr")
-		assert.Equal(t, err.(errs.OptionArgIsInvalid).Option, "int-arr")
-		assert.Equal(t, err.(errs.OptionArgIsInvalid).OptArg, "")
-		assert.Equal(t, err.(errs.OptionArgIsInvalid).TypeKind, reflect.Int)
+	case cliargs.OptionArgIsInvalid:
+		assert.Equal(t, err.(cliargs.OptionArgIsInvalid).StoreKey, "IntArr")
+		assert.Equal(t, err.(cliargs.OptionArgIsInvalid).Option, "int-arr")
+		assert.Equal(t, err.(cliargs.OptionArgIsInvalid).OptArg, "")
+		assert.Equal(t, err.(cliargs.OptionArgIsInvalid).TypeKind, reflect.Int)
 	default:
 		assert.Fail(t, err.Error())
 	}
@@ -1599,11 +1598,11 @@ func TestParseFor_errorEmptyDefaultValueIfOptionIsUintArray(t *testing.T) {
 	)
 	assert.NotNil(t, errors.Unwrap(err))
 	switch err.(type) {
-	case errs.OptionArgIsInvalid:
-		assert.Equal(t, err.(errs.OptionArgIsInvalid).StoreKey, "UintArr")
-		assert.Equal(t, err.(errs.OptionArgIsInvalid).Option, "uint-arr")
-		assert.Equal(t, err.(errs.OptionArgIsInvalid).OptArg, "")
-		assert.Equal(t, err.(errs.OptionArgIsInvalid).TypeKind, reflect.Uint)
+	case cliargs.OptionArgIsInvalid:
+		assert.Equal(t, err.(cliargs.OptionArgIsInvalid).StoreKey, "UintArr")
+		assert.Equal(t, err.(cliargs.OptionArgIsInvalid).Option, "uint-arr")
+		assert.Equal(t, err.(cliargs.OptionArgIsInvalid).OptArg, "")
+		assert.Equal(t, err.(cliargs.OptionArgIsInvalid).TypeKind, reflect.Uint)
 	default:
 		assert.Fail(t, err.Error())
 	}
@@ -1632,11 +1631,11 @@ func TestParseFor_errorEmptyDefaultValueIfOptionIsFloatArray(t *testing.T) {
 	)
 	assert.NotNil(t, errors.Unwrap(err))
 	switch err.(type) {
-	case errs.OptionArgIsInvalid:
-		assert.Equal(t, err.(errs.OptionArgIsInvalid).StoreKey, "Float64Arr")
-		assert.Equal(t, err.(errs.OptionArgIsInvalid).Option, "float-arr")
-		assert.Equal(t, err.(errs.OptionArgIsInvalid).OptArg, "")
-		assert.Equal(t, err.(errs.OptionArgIsInvalid).TypeKind, reflect.Float64)
+	case cliargs.OptionArgIsInvalid:
+		assert.Equal(t, err.(cliargs.OptionArgIsInvalid).StoreKey, "Float64Arr")
+		assert.Equal(t, err.(cliargs.OptionArgIsInvalid).Option, "float-arr")
+		assert.Equal(t, err.(cliargs.OptionArgIsInvalid).OptArg, "")
+		assert.Equal(t, err.(cliargs.OptionArgIsInvalid).TypeKind, reflect.Float64)
 	default:
 		assert.Fail(t, err.Error())
 	}
@@ -1701,10 +1700,10 @@ func TestParseFor_errorIfDefaultValueIsInvalidType(t *testing.T) {
 	assert.NotNil(t, err)
 	assert.Equal(t, err.Error(), "BadFieldType{Option:BoolArr,Field:BoolArr,Type:[]bool}")
 	switch err.(type) {
-	case errs.BadFieldType:
-		assert.Equal(t, err.(errs.BadFieldType).Option, "BoolArr")
-		assert.Equal(t, err.(errs.BadFieldType).Field, "BoolArr")
-		assert.Equal(t, err.(errs.BadFieldType).Type, reflect.TypeOf(options.BoolArr))
+	case cliargs.BadFieldType:
+		assert.Equal(t, err.(cliargs.BadFieldType).Option, "BoolArr")
+		assert.Equal(t, err.(cliargs.BadFieldType).Field, "BoolArr")
+		assert.Equal(t, err.(cliargs.BadFieldType).Type, reflect.TypeOf(options.BoolArr))
 	default:
 		assert.Fail(t, err.Error())
 	}
@@ -1898,10 +1897,10 @@ func TestParseFor_optCfgHasUnsupportedType(t *testing.T) {
 		"Option:foo-bar,Field:FooBar,Type:cliargs_test.A}",
 	)
 	switch err.(type) {
-	case errs.BadFieldType:
-		assert.Equal(t, err.(errs.BadFieldType).Option, "foo-bar")
-		assert.Equal(t, err.(errs.BadFieldType).Field, "FooBar")
-		assert.Equal(t, err.(errs.BadFieldType).Type.(reflect.Type).Name(), "A")
+	case cliargs.BadFieldType:
+		assert.Equal(t, err.(cliargs.BadFieldType).Option, "foo-bar")
+		assert.Equal(t, err.(cliargs.BadFieldType).Field, "FooBar")
+		assert.Equal(t, err.(cliargs.BadFieldType).Type.(reflect.Type).Name(), "A")
 	default:
 		assert.Fail(t, err.Error())
 	}
@@ -1924,7 +1923,7 @@ func TestParseFor_argIsNotPointer(t *testing.T) {
 	assert.NotNil(t, err)
 	assert.Equal(t, err.Error(), "OptionStoreIsNotChangeable{}")
 	switch err.(type) {
-	case errs.OptionStoreIsNotChangeable:
+	case cliargs.OptionStoreIsNotChangeable:
 	default:
 		assert.Fail(t, err.Error())
 	}
@@ -2013,10 +2012,10 @@ func TestParseUntilSubCmdFor_error0(t *testing.T) {
 	subCmd, err := cmd.ParseUntilSubCmdFor(&options)
 
 	switch err.(type) {
-	case errs.BadFieldType:
-		assert.Equal(t, err.(errs.BadFieldType).Option, "foo-bar")
-		assert.Equal(t, err.(errs.BadFieldType).Field, "FooBar")
-		assert.Equal(t, err.(errs.BadFieldType).Type, reflect.TypeOf(options.FooBar))
+	case cliargs.BadFieldType:
+		assert.Equal(t, err.(cliargs.BadFieldType).Option, "foo-bar")
+		assert.Equal(t, err.(cliargs.BadFieldType).Field, "FooBar")
+		assert.Equal(t, err.(cliargs.BadFieldType).Type, reflect.TypeOf(options.FooBar))
 	default:
 		assert.Fail(t, err.Error())
 	}
@@ -2045,12 +2044,12 @@ func TestParseUntilSubCmdFor_error1(t *testing.T) {
 	subCmd, err := cmd.ParseUntilSubCmdFor(&options)
 
 	switch err.(type) {
-	case errs.OptionArgIsInvalid:
-		assert.Equal(t, err.(errs.OptionArgIsInvalid).StoreKey, "FooBar")
-		assert.Equal(t, err.(errs.OptionArgIsInvalid).Option, "foo-bar")
-		assert.Equal(t, err.(errs.OptionArgIsInvalid).OptArg, "baz")
-		assert.Equal(t, err.(errs.OptionArgIsInvalid).TypeKind, reflect.Int)
-		assert.Equal(t, err.(errs.OptionArgIsInvalid).Cause.Error(), "strconv.ParseInt: parsing \"baz\": invalid syntax")
+	case cliargs.OptionArgIsInvalid:
+		assert.Equal(t, err.(cliargs.OptionArgIsInvalid).StoreKey, "FooBar")
+		assert.Equal(t, err.(cliargs.OptionArgIsInvalid).Option, "foo-bar")
+		assert.Equal(t, err.(cliargs.OptionArgIsInvalid).OptArg, "baz")
+		assert.Equal(t, err.(cliargs.OptionArgIsInvalid).TypeKind, reflect.Int)
+		assert.Equal(t, err.(cliargs.OptionArgIsInvalid).Cause.Error(), "strconv.ParseInt: parsing \"baz\": invalid syntax")
 	default:
 		assert.Fail(t, err.Error())
 	}

--- a/parse-with.go
+++ b/parse-with.go
@@ -4,10 +4,6 @@
 
 package cliargs
 
-import (
-	"github.com/sttk/cliargs/errors"
-)
-
 const anyOption = "*"
 
 // ParseWith is the method which parses command line arguments with option configurations.
@@ -108,18 +104,18 @@ func (cmd *Cmd) parseArgsWith(
 
 		_, exists := optMap[storeKey]
 		if exists {
-			e := errors.StoreKeyIsDuplicated{StoreKey: storeKey, Name: firstName}
+			e := StoreKeyIsDuplicated{StoreKey: storeKey, Name: firstName}
 			return -1, cmd.isAfterEndOpt, e
 		}
 		optMap[storeKey] = EMPTY_STRUCT
 
 		if !cfg.HasArg {
 			if cfg.IsArray {
-				e := errors.ConfigIsArrayButHasNoArg{StoreKey: storeKey, Name: firstName}
+				e := ConfigIsArrayButHasNoArg{StoreKey: storeKey, Name: firstName}
 				return -1, cmd.isAfterEndOpt, e
 			}
 			if cfg.Defaults != nil {
-				e := errors.ConfigHasDefaultsButHasNoArg{StoreKey: storeKey, Name: firstName}
+				e := ConfigHasDefaultsButHasNoArg{StoreKey: storeKey, Name: firstName}
 				return -1, cmd.isAfterEndOpt, e
 			}
 		}
@@ -130,7 +126,7 @@ func (cmd *Cmd) parseArgsWith(
 			for _, nm := range cfg.Names {
 				_, exists := cfgMap[nm]
 				if exists {
-					e := errors.OptionNameIsDuplicated{StoreKey: storeKey, Name: nm}
+					e := OptionNameIsDuplicated{StoreKey: storeKey, Name: nm}
 					return -1, cmd.isAfterEndOpt, e
 				}
 				cfgMap[nm] = i
@@ -169,7 +165,7 @@ func (cmd *Cmd) parseArgsWith(
 
 			if len(a) > 0 {
 				if !cfg.HasArg {
-					return errors.OptionTakesNoArg{
+					return OptionTakesNoArg{
 						Option:   name,
 						StoreKey: storeKey,
 					}
@@ -178,7 +174,7 @@ func (cmd *Cmd) parseArgsWith(
 				arr, _ := cmd.opts[storeKey]
 				if len(arr) > 0 {
 					if !cfg.IsArray {
-						return errors.OptionIsNotArray{
+						return OptionIsNotArray{
 							StoreKey: storeKey,
 							Option:   name,
 						}
@@ -201,7 +197,7 @@ func (cmd *Cmd) parseArgsWith(
 				}
 			} else {
 				if cfg.HasArg {
-					return errors.OptionNeedsArg{
+					return OptionNeedsArg{
 						Option:   name,
 						StoreKey: storeKey,
 					}
@@ -216,7 +212,7 @@ func (cmd *Cmd) parseArgsWith(
 			return nil
 		} else {
 			if !hasAnyOpt {
-				return errors.UnconfiguredOption{
+				return UnconfiguredOption{
 					Option: name,
 				}
 			}

--- a/parse-with_test.go
+++ b/parse-with_test.go
@@ -7,8 +7,6 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/sttk/cliargs"
-	"github.com/sttk/cliargs/errors"
-	"github.com/sttk/cliargs/validators"
 )
 
 func TestParseWith_zeroCfgAndZeroArg(t *testing.T) {
@@ -61,13 +59,13 @@ func TestParseWith_zeroCfgAndOneLongOpt(t *testing.T) {
 	assert.Equal(t, err.Error(), "UnconfiguredOption{Option:foo-bar}")
 
 	switch e := err.(type) {
-	case errors.UnconfiguredOption:
+	case cliargs.UnconfiguredOption:
 		assert.Equal(t, e.Option, "foo-bar")
 	default:
 		assert.Fail(t, err.Error())
 	}
 	switch e := err.(type) {
-	case errors.InvalidOption:
+	case cliargs.InvalidOption:
 		assert.Equal(t, e.GetOption(), "foo-bar")
 	default:
 		assert.Fail(t, err.Error())
@@ -97,13 +95,13 @@ func TestParseWith_zeroCfgAndOneShortOpt(t *testing.T) {
 	assert.Equal(t, err.Error(), "UnconfiguredOption{Option:f}")
 
 	switch e := err.(type) {
-	case errors.UnconfiguredOption:
+	case cliargs.UnconfiguredOption:
 		assert.Equal(t, e.Option, "f")
 	default:
 		assert.Fail(t, err.Error())
 	}
 	switch e := err.(type) {
-	case errors.InvalidOption:
+	case cliargs.InvalidOption:
 		assert.Equal(t, e.GetOption(), "f")
 	default:
 		assert.Fail(t, err.Error())
@@ -226,13 +224,13 @@ func TestParseWith_oneCfgAndOneDifferentLongOpt(t *testing.T) {
 	assert.NotNil(t, err)
 	assert.Equal(t, err.Error(), "UnconfiguredOption{Option:boo-far}")
 	switch e := err.(type) {
-	case errors.UnconfiguredOption:
+	case cliargs.UnconfiguredOption:
 		assert.Equal(t, e.Option, "boo-far")
 	default:
 		assert.Fail(t, err.Error())
 	}
 	switch e := err.(type) {
-	case errors.InvalidOption:
+	case cliargs.InvalidOption:
 		assert.Equal(t, e.GetOption(), "boo-far")
 	default:
 		assert.Fail(t, err.Error())
@@ -263,13 +261,13 @@ func TestParseWith_oneCfgAndOneDifferentShortOpt(t *testing.T) {
 	assert.NotNil(t, err)
 	assert.Equal(t, err.Error(), "UnconfiguredOption{Option:b}")
 	switch e := err.(type) {
-	case errors.UnconfiguredOption:
+	case cliargs.UnconfiguredOption:
 		assert.Equal(t, e.Option, "b")
 	default:
 		assert.Fail(t, err.Error())
 	}
 	switch e := err.(type) {
-	case errors.InvalidOption:
+	case cliargs.InvalidOption:
 		assert.Equal(t, e.GetOption(), "b")
 	default:
 		assert.Fail(t, err.Error())
@@ -492,14 +490,14 @@ func TestParseWith_oneCfgHasArgButOneLongOptHasNoArg(t *testing.T) {
 	assert.NotNil(t, err)
 	assert.Equal(t, err.Error(), "OptionNeedsArg{Option:foo-bar,StoreKey:foo-bar}")
 	switch e := err.(type) {
-	case errors.OptionNeedsArg:
+	case cliargs.OptionNeedsArg:
 		assert.Equal(t, e.Option, "foo-bar")
 		assert.Equal(t, e.StoreKey, "foo-bar")
 	default:
 		assert.Fail(t, err.Error())
 	}
 	switch e := err.(type) {
-	case errors.InvalidOption:
+	case cliargs.InvalidOption:
 		assert.Equal(t, e.GetOption(), "foo-bar")
 	default:
 		assert.Fail(t, err.Error())
@@ -530,14 +528,14 @@ func TestParseWith_oneCfgHasArgAndOneShortOptHasNoArg(t *testing.T) {
 	assert.NotNil(t, err)
 	assert.Equal(t, err.Error(), "OptionNeedsArg{Option:f,StoreKey:f}")
 	switch e := err.(type) {
-	case errors.OptionNeedsArg:
+	case cliargs.OptionNeedsArg:
 		assert.Equal(t, e.Option, "f")
 		assert.Equal(t, e.StoreKey, "f")
 	default:
 		assert.Fail(t, err.Error())
 	}
 	switch e := err.(type) {
-	case errors.InvalidOption:
+	case cliargs.InvalidOption:
 		assert.Equal(t, e.GetOption(), "f")
 	default:
 		assert.Fail(t, err.Error())
@@ -583,14 +581,14 @@ func TestParseWith_oneCfgHasNoArgAndOneLongOptHasArg(t *testing.T) {
 	assert.NotNil(t, err)
 	assert.Equal(t, err.Error(), "OptionTakesNoArg{Option:foo-bar,StoreKey:foo-bar}")
 	switch e := err.(type) {
-	case errors.OptionTakesNoArg:
+	case cliargs.OptionTakesNoArg:
 		assert.Equal(t, e.Option, "foo-bar")
 		assert.Equal(t, e.StoreKey, "foo-bar")
 	default:
 		assert.Fail(t, err.Error())
 	}
 	switch e := err.(type) {
-	case errors.InvalidOption:
+	case cliargs.InvalidOption:
 		assert.Equal(t, e.GetOption(), "foo-bar")
 	default:
 		assert.Fail(t, err.Error())
@@ -628,14 +626,14 @@ func TestParseWith_oneCfgHasNoArgAndOneLongOptHasArg(t *testing.T) {
 	assert.NotNil(t, err)
 	assert.Equal(t, err.Error(), "OptionTakesNoArg{Option:foo-bar,StoreKey:foo-bar}")
 	switch e := err.(type) {
-	case errors.OptionTakesNoArg:
+	case cliargs.OptionTakesNoArg:
 		assert.Equal(t, e.Option, "foo-bar")
 		assert.Equal(t, e.StoreKey, "foo-bar")
 	default:
 		assert.Fail(t, err.Error())
 	}
 	switch e := err.(type) {
-	case errors.InvalidOption:
+	case cliargs.InvalidOption:
 		assert.Equal(t, e.GetOption(), "foo-bar")
 	default:
 		assert.Fail(t, err.Error())
@@ -681,14 +679,14 @@ func TestParseWith_oneCfgHasNoArgAndOneShortOptHasArg(t *testing.T) {
 	assert.NotNil(t, err)
 	assert.Equal(t, err.Error(), "OptionTakesNoArg{Option:f,StoreKey:f}")
 	switch e := err.(type) {
-	case errors.OptionTakesNoArg:
+	case cliargs.OptionTakesNoArg:
 		assert.Equal(t, e.Option, "f")
 		assert.Equal(t, e.StoreKey, "f")
 	default:
 		assert.Fail(t, err.Error())
 	}
 	switch e := err.(type) {
-	case errors.InvalidOption:
+	case cliargs.InvalidOption:
 		assert.Equal(t, e.GetOption(), "f")
 	default:
 		assert.Fail(t, err.Error())
@@ -726,14 +724,14 @@ func TestParseWith_oneCfgHasNoArgAndOneShortOptHasArg(t *testing.T) {
 	assert.NotNil(t, err)
 	assert.Equal(t, err.Error(), "OptionTakesNoArg{Option:f,StoreKey:f}")
 	switch e := err.(type) {
-	case errors.OptionTakesNoArg:
+	case cliargs.OptionTakesNoArg:
 		assert.Equal(t, e.Option, "f")
 		assert.Equal(t, e.StoreKey, "f")
 	default:
 		assert.Fail(t, err.Error())
 	}
 	switch e := err.(type) {
-	case errors.InvalidOption:
+	case cliargs.InvalidOption:
 		assert.Equal(t, e.GetOption(), "f")
 	default:
 		assert.Fail(t, err.Error())
@@ -764,14 +762,14 @@ func TestParseWith_oneCfgHasNoArgButIsArray(t *testing.T) {
 	assert.NotNil(t, err)
 	assert.Equal(t, err.Error(), "ConfigIsArrayButHasNoArg{StoreKey:foo-bar,Name:foo-bar}")
 	switch e := err.(type) {
-	case errors.ConfigIsArrayButHasNoArg:
+	case cliargs.ConfigIsArrayButHasNoArg:
 		assert.Equal(t, e.StoreKey, "foo-bar")
 		assert.Equal(t, e.Name, "foo-bar")
 	default:
 		assert.Fail(t, err.Error())
 	}
 	switch e := err.(type) {
-	case errors.InvalidOption:
+	case cliargs.InvalidOption:
 		assert.Equal(t, e.GetOption(), "foo-bar")
 	default:
 		assert.Fail(t, err.Error())
@@ -958,14 +956,14 @@ func TestParseWith_oneCfgIsNotArrayButOptsAreMultiple(t *testing.T) {
 	assert.NotNil(t, err)
 	assert.Equal(t, err.Error(), "OptionIsNotArray{Option:foo-bar,StoreKey:foo-bar}")
 	switch e := err.(type) {
-	case errors.OptionIsNotArray:
+	case cliargs.OptionIsNotArray:
 		assert.Equal(t, e.Option, "foo-bar")
 		assert.Equal(t, e.StoreKey, "foo-bar")
 	default:
 		assert.Fail(t, err.Error())
 	}
 	switch e := err.(type) {
-	case errors.InvalidOption:
+	case cliargs.InvalidOption:
 		assert.Equal(t, e.GetOption(), "foo-bar")
 	default:
 		assert.Fail(t, err.Error())
@@ -988,14 +986,14 @@ func TestParseWith_oneCfgIsNotArrayButOptsAreMultiple(t *testing.T) {
 	assert.NotNil(t, err)
 	assert.Equal(t, err.Error(), "OptionIsNotArray{Option:foo-bar,StoreKey:foo-bar}")
 	switch e := err.(type) {
-	case errors.OptionIsNotArray:
+	case cliargs.OptionIsNotArray:
 		assert.Equal(t, e.Option, "foo-bar")
 		assert.Equal(t, e.StoreKey, "foo-bar")
 	default:
 		assert.Fail(t, err.Error())
 	}
 	switch e := err.(type) {
-	case errors.InvalidOption:
+	case cliargs.InvalidOption:
 		assert.Equal(t, e.GetOption(), "foo-bar")
 	default:
 		assert.Fail(t, err.Error())
@@ -1053,14 +1051,14 @@ func TestParseWith_oneCfgHasNoArgButHasDefault(t *testing.T) {
 	assert.NotNil(t, err)
 	assert.Equal(t, err.Error(), "ConfigHasDefaultsButHasNoArg{StoreKey:foo-bar,Name:foo-bar}")
 	switch e := err.(type) {
-	case errors.ConfigHasDefaultsButHasNoArg:
+	case cliargs.ConfigHasDefaultsButHasNoArg:
 		assert.Equal(t, e.StoreKey, "foo-bar")
 		assert.Equal(t, e.Name, "foo-bar")
 	default:
 		assert.Fail(t, err.Error())
 	}
 	switch e := err.(type) {
-	case errors.InvalidOption:
+	case cliargs.InvalidOption:
 		assert.Equal(t, e.GetOption(), "foo-bar")
 	default:
 		assert.Fail(t, err.Error())
@@ -1127,13 +1125,13 @@ func TestParseWith_parseAllArgsEvenIfError(t *testing.T) {
 	assert.False(t, cmd.HasOpt("e"))
 
 	switch e := err.(type) {
-	case errors.UnconfiguredOption:
+	case cliargs.UnconfiguredOption:
 		assert.Equal(t, e.Option, "e")
 	default:
 		assert.Fail(t, err.Error())
 	}
 	switch e := err.(type) {
-	case errors.InvalidOption:
+	case cliargs.InvalidOption:
 		assert.Equal(t, e.GetOption(), "e")
 	default:
 		assert.Fail(t, err.Error())
@@ -1160,14 +1158,14 @@ func TestParseWith_parseAllArgsEvenIfShortOptionValueIsError(t *testing.T) {
 	assert.True(t, cmd.HasOpt("e"))
 
 	switch e := err.(type) {
-	case errors.OptionTakesNoArg:
+	case cliargs.OptionTakesNoArg:
 		assert.Equal(t, e.Option, "f")
 		assert.Equal(t, e.StoreKey, "foo")
 	default:
 		assert.Fail(t, err.Error())
 	}
 	switch e := err.(type) {
-	case errors.InvalidOption:
+	case cliargs.InvalidOption:
 		assert.Equal(t, e.GetOption(), "f")
 	default:
 		assert.Fail(t, err.Error())
@@ -1194,14 +1192,14 @@ func TestParseWith_parseAllArgsEvenIfLongOptionValueIsError(t *testing.T) {
 	assert.True(t, cmd.HasOpt("e"))
 
 	switch e := err.(type) {
-	case errors.OptionTakesNoArg:
+	case cliargs.OptionTakesNoArg:
 		assert.Equal(t, e.Option, "foo")
 		assert.Equal(t, e.StoreKey, "foo")
 	default:
 		assert.Fail(t, err.Error())
 	}
 	switch e := err.(type) {
-	case errors.InvalidOption:
+	case cliargs.InvalidOption:
 		assert.Equal(t, e.GetOption(), "foo")
 	default:
 		assert.Fail(t, err.Error())
@@ -1247,14 +1245,14 @@ func TestParseWith_optionNameIsDuplicated(t *testing.T) {
 
 	assert.Equal(t, err.Error(), "OptionNameIsDuplicated{StoreKey:bar,Name:f}")
 	switch e := err.(type) {
-	case errors.OptionNameIsDuplicated:
+	case cliargs.OptionNameIsDuplicated:
 		assert.Equal(t, e.Name, "f")
 		assert.Equal(t, e.StoreKey, "bar")
 	default:
 		assert.Fail(t, err.Error())
 	}
 	switch e := err.(type) {
-	case errors.InvalidOption:
+	case cliargs.InvalidOption:
 		assert.Equal(t, e.GetOption(), "f")
 	default:
 		assert.Fail(t, err.Error())
@@ -1309,14 +1307,14 @@ func TestParseWith_StoreKeyIsDuplicated(t *testing.T) {
 
 	assert.Equal(t, err.Error(), "StoreKeyIsDuplicated{StoreKey:FooBar,Name:b}")
 	switch e := err.(type) {
-	case errors.StoreKeyIsDuplicated:
+	case cliargs.StoreKeyIsDuplicated:
 		assert.Equal(t, e.StoreKey, "FooBar")
 		assert.Equal(t, e.Name, "b")
 	default:
 		assert.Fail(t, err.Error())
 	}
 	switch e := err.(type) {
-	case errors.InvalidOption:
+	case cliargs.InvalidOption:
 		assert.Equal(t, e.GetOption(), "b")
 	default:
 		assert.Fail(t, err.Error())
@@ -1375,7 +1373,7 @@ func TestParseWith_oneCfgUsingValidator(t *testing.T) {
 		cliargs.OptCfg{
 			StoreKey:  "foo",
 			HasArg:    true,
-			Validator: &validators.ValidateInt16,
+			Validator: &cliargs.ValidateInt16,
 		},
 	}
 
@@ -1403,7 +1401,7 @@ func TestParseWith_oneCfgUsingValidator_validationError(t *testing.T) {
 			StoreKey:  "Foo",
 			Names:     []string{"foo", "f"},
 			HasArg:    true,
-			Validator: &validators.ValidateInt8,
+			Validator: &cliargs.ValidateInt8,
 		},
 	}
 
@@ -1413,7 +1411,7 @@ func TestParseWith_oneCfgUsingValidator_validationError(t *testing.T) {
 	err := cmd.ParseWith(optCfgs)
 
 	switch e := err.(type) {
-	case errors.OptionArgIsInvalid:
+	case cliargs.OptionArgIsInvalid:
 		assert.Equal(t, e.StoreKey, "Foo")
 		assert.Equal(t, e.Option, "f")
 		assert.Equal(t, e.OptArg, "128")
@@ -1422,7 +1420,7 @@ func TestParseWith_oneCfgUsingValidator_validationError(t *testing.T) {
 		assert.Fail(t, err.Error())
 	}
 	switch e := err.(type) {
-	case errors.InvalidOption:
+	case cliargs.InvalidOption:
 		assert.Equal(t, e.GetOption(), "f")
 	default:
 		assert.Fail(t, err.Error())
@@ -1444,7 +1442,7 @@ func TestParseWith_oneCfgBeingArrayAndUsingValidator(t *testing.T) {
 			Names:     []string{"foo", "f"},
 			HasArg:    true,
 			IsArray:   true,
-			Validator: &validators.ValidateInt32,
+			Validator: &cliargs.ValidateInt32,
 		},
 	}
 
@@ -1470,7 +1468,7 @@ func TestParseWith_oneCfgBeingArrayAndUsingValidator_validationError(t *testing.
 			Names:     []string{"foo", "f"},
 			HasArg:    true,
 			IsArray:   true,
-			Validator: &validators.ValidateInt32,
+			Validator: &cliargs.ValidateInt32,
 		},
 	}
 
@@ -1480,7 +1478,7 @@ func TestParseWith_oneCfgBeingArrayAndUsingValidator_validationError(t *testing.
 	err := cmd.ParseWith(optCfgs)
 
 	switch e := err.(type) {
-	case errors.OptionArgIsInvalid:
+	case cliargs.OptionArgIsInvalid:
 		assert.Equal(t, e.StoreKey, "Foo")
 		assert.Equal(t, e.Option, "foo")
 		assert.Equal(t, e.OptArg, "ABC")
@@ -1489,7 +1487,7 @@ func TestParseWith_oneCfgBeingArrayAndUsingValidator_validationError(t *testing.
 		assert.Fail(t, err.Error())
 	}
 	switch e := err.(type) {
-	case errors.InvalidOption:
+	case cliargs.InvalidOption:
 		assert.Equal(t, e.GetOption(), "foo")
 	default:
 		assert.Fail(t, err.Error())
@@ -1574,13 +1572,13 @@ func TestParseUntilSubCmdWith_zeroCfg_oneOptWithNoArg(t *testing.T) {
 	assert.Equal(t, err.Error(), "UnconfiguredOption{Option:foo-bar}")
 
 	switch e := err.(type) {
-	case errors.UnconfiguredOption:
+	case cliargs.UnconfiguredOption:
 		assert.Equal(t, e.Option, "foo-bar")
 	default:
 		assert.Fail(t, err.Error())
 	}
 	switch e := err.(type) {
-	case errors.InvalidOption:
+	case cliargs.InvalidOption:
 		assert.Equal(t, e.GetOption(), "foo-bar")
 	default:
 		assert.Fail(t, err.Error())
@@ -1791,7 +1789,7 @@ func TestParseUntilSubCmdWith_oneCfgUsingValidatorAndSubCmd(t *testing.T) {
 		cliargs.OptCfg{
 			StoreKey:  "foo",
 			HasArg:    true,
-			Validator: &validators.ValidateInt32,
+			Validator: &cliargs.ValidateInt32,
 		},
 	}
 

--- a/parse.go
+++ b/parse.go
@@ -7,8 +7,6 @@ package cliargs
 import (
 	"strings"
 	"unicode"
-
-	"github.com/sttk/cliargs/errors"
 )
 
 var (
@@ -148,14 +146,14 @@ L0:
 					}
 					if !unicode.Is(rangeOfAlNumMarks, r) {
 						if firstErr == nil {
-							firstErr = errors.OptionContainsInvalidChar{Option: arg}
+							firstErr = OptionContainsInvalidChar{Option: arg}
 						}
 						continue L0
 					}
 				} else {
 					if !unicode.Is(rangeOfAlphabets, r) {
 						if firstErr == nil {
-							firstErr = errors.OptionContainsInvalidChar{Option: arg}
+							firstErr = OptionContainsInvalidChar{Option: arg}
 						}
 						continue L0
 					}
@@ -214,7 +212,7 @@ L0:
 				}
 				if !unicode.Is(rangeOfAlphabets, r) {
 					if firstErr == nil {
-						firstErr = errors.OptionContainsInvalidChar{Option: string(r)}
+						firstErr = OptionContainsInvalidChar{Option: string(r)}
 					}
 					name = ""
 				} else {

--- a/parse_test.go
+++ b/parse_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/sttk/cliargs"
-	"github.com/sttk/cliargs/errors"
 )
 
 var origOsArgs []string = os.Args
@@ -330,13 +329,13 @@ func TestParse_illegalLongOptIfIncludingInvalidChar(t *testing.T) {
 	assert.NotNil(t, err)
 	assert.Equal(t, err.Error(), "OptionContainsInvalidChar{Option:abc%def}")
 	switch e := err.(type) {
-	case errors.OptionContainsInvalidChar:
+	case cliargs.OptionContainsInvalidChar:
 		assert.Equal(t, e.Option, "abc%def")
 	default:
 		assert.Fail(t, err.Error())
 	}
 	switch e := err.(type) {
-	case errors.InvalidOption:
+	case cliargs.InvalidOption:
 		assert.Equal(t, e.GetOption(), "abc%def")
 	default:
 		assert.Fail(t, err.Error())
@@ -371,13 +370,13 @@ func TestParse_illegalLongOptIfFirstCharIsNumber(t *testing.T) {
 	assert.NotNil(t, err)
 	assert.Equal(t, err.Error(), "OptionContainsInvalidChar{Option:1abc}")
 	switch e := err.(type) {
-	case errors.OptionContainsInvalidChar:
+	case cliargs.OptionContainsInvalidChar:
 		assert.Equal(t, e.Option, "1abc")
 	default:
 		assert.Fail(t, err.Error())
 	}
 	switch e := err.(type) {
-	case errors.InvalidOption:
+	case cliargs.InvalidOption:
 		assert.Equal(t, e.GetOption(), "1abc")
 	default:
 		assert.Fail(t, err.Error())
@@ -412,13 +411,13 @@ func TestParse_illegalLongOptIfFirstCharIsHyphen(t *testing.T) {
 	assert.NotNil(t, err)
 	assert.Equal(t, err.Error(), "OptionContainsInvalidChar{Option:-aaa=123}")
 	switch e := err.(type) {
-	case errors.OptionContainsInvalidChar:
+	case cliargs.OptionContainsInvalidChar:
 		assert.Equal(t, e.Option, "-aaa=123")
 	default:
 		assert.Fail(t, err.Error())
 	}
 	switch e := err.(type) {
-	case errors.InvalidOption:
+	case cliargs.InvalidOption:
 		assert.Equal(t, e.GetOption(), "-aaa=123")
 	default:
 		assert.Fail(t, err.Error())
@@ -455,13 +454,13 @@ func TestParse_IllegalCharInShortOpt(t *testing.T) {
 	assert.NotNil(t, err)
 	assert.Equal(t, err.Error(), "OptionContainsInvalidChar{Option:@}")
 	switch e := err.(type) {
-	case errors.OptionContainsInvalidChar:
+	case cliargs.OptionContainsInvalidChar:
 		assert.Equal(t, e.Option, "@")
 	default:
 		assert.Fail(t, err.Error())
 	}
 	switch e := err.(type) {
-	case errors.InvalidOption:
+	case cliargs.InvalidOption:
 		assert.Equal(t, e.GetOption(), "@")
 	default:
 		assert.Fail(t, err.Error())
@@ -587,13 +586,13 @@ func TestParse_parseAllArgsEvenIfError(t *testing.T) {
 	err := cmd.Parse()
 
 	switch e := err.(type) {
-	case errors.OptionContainsInvalidChar:
+	case cliargs.OptionContainsInvalidChar:
 		assert.Equal(t, e.Option, "1")
 	default:
 		assert.Fail(t, err.Error())
 	}
 	switch e := err.(type) {
-	case errors.InvalidOption:
+	case cliargs.InvalidOption:
 		assert.Equal(t, e.GetOption(), "1")
 	default:
 		assert.Fail(t, err.Error())

--- a/validators.go
+++ b/validators.go
@@ -2,21 +2,17 @@
 // This program is free software under MIT License.
 // See the file LICENSE in this distribution for more details.
 
-// Package validators contains valiators that checks the number format of the string specified as
-// an option argument in command line arguments.
-package validators
+package cliargs
 
 import (
 	"reflect"
 	"strconv"
-
-	"github.com/sttk/cliargs/errors"
 )
 
 func validateInt(storeKey string, option string, optArg string) error {
 	_, e := strconv.ParseInt(optArg, 0, strconv.IntSize)
 	if e != nil {
-		return errors.OptionArgIsInvalid{
+		return OptionArgIsInvalid{
 			StoreKey: storeKey, Option: option, OptArg: optArg, TypeKind: reflect.Int, Cause: e}
 	}
 	return nil
@@ -25,7 +21,7 @@ func validateInt(storeKey string, option string, optArg string) error {
 func validateInt8(storeKey string, option string, optArg string) error {
 	_, e := strconv.ParseInt(optArg, 0, 8)
 	if e != nil {
-		return errors.OptionArgIsInvalid{
+		return OptionArgIsInvalid{
 			StoreKey: storeKey, Option: option, OptArg: optArg, TypeKind: reflect.Int8, Cause: e}
 	}
 	return nil
@@ -34,7 +30,7 @@ func validateInt8(storeKey string, option string, optArg string) error {
 func validateInt16(storeKey string, option string, optArg string) error {
 	_, e := strconv.ParseInt(optArg, 0, 16)
 	if e != nil {
-		return errors.OptionArgIsInvalid{
+		return OptionArgIsInvalid{
 			StoreKey: storeKey, Option: option, OptArg: optArg, TypeKind: reflect.Int16, Cause: e}
 	}
 	return nil
@@ -43,7 +39,7 @@ func validateInt16(storeKey string, option string, optArg string) error {
 func validateInt32(storeKey string, option string, optArg string) error {
 	_, e := strconv.ParseInt(optArg, 0, 32)
 	if e != nil {
-		return errors.OptionArgIsInvalid{
+		return OptionArgIsInvalid{
 			StoreKey: storeKey, Option: option, OptArg: optArg, TypeKind: reflect.Int32, Cause: e}
 	}
 	return nil
@@ -52,7 +48,7 @@ func validateInt32(storeKey string, option string, optArg string) error {
 func validateInt64(storeKey string, option string, optArg string) error {
 	_, e := strconv.ParseInt(optArg, 0, 64)
 	if e != nil {
-		return errors.OptionArgIsInvalid{
+		return OptionArgIsInvalid{
 			StoreKey: storeKey, Option: option, OptArg: optArg, TypeKind: reflect.Int64, Cause: e}
 	}
 	return nil
@@ -61,7 +57,7 @@ func validateInt64(storeKey string, option string, optArg string) error {
 func validateUint(storeKey string, option string, optArg string) error {
 	_, e := strconv.ParseUint(optArg, 0, strconv.IntSize)
 	if e != nil {
-		return errors.OptionArgIsInvalid{
+		return OptionArgIsInvalid{
 			StoreKey: storeKey, Option: option, OptArg: optArg, TypeKind: reflect.Uint, Cause: e}
 	}
 	return nil
@@ -70,7 +66,7 @@ func validateUint(storeKey string, option string, optArg string) error {
 func validateUint8(storeKey string, option string, optArg string) error {
 	_, e := strconv.ParseUint(optArg, 0, 8)
 	if e != nil {
-		return errors.OptionArgIsInvalid{
+		return OptionArgIsInvalid{
 			StoreKey: storeKey, Option: option, OptArg: optArg, TypeKind: reflect.Uint8, Cause: e}
 	}
 	return nil
@@ -79,7 +75,7 @@ func validateUint8(storeKey string, option string, optArg string) error {
 func validateUint16(storeKey string, option string, optArg string) error {
 	_, e := strconv.ParseUint(optArg, 0, 16)
 	if e != nil {
-		return errors.OptionArgIsInvalid{
+		return OptionArgIsInvalid{
 			StoreKey: storeKey, Option: option, OptArg: optArg, TypeKind: reflect.Uint16, Cause: e}
 	}
 	return nil
@@ -88,7 +84,7 @@ func validateUint16(storeKey string, option string, optArg string) error {
 func validateUint32(storeKey string, option string, optArg string) error {
 	_, e := strconv.ParseUint(optArg, 0, 32)
 	if e != nil {
-		return errors.OptionArgIsInvalid{
+		return OptionArgIsInvalid{
 			StoreKey: storeKey, Option: option, OptArg: optArg, TypeKind: reflect.Uint32, Cause: e}
 	}
 	return nil
@@ -97,7 +93,7 @@ func validateUint32(storeKey string, option string, optArg string) error {
 func validateUint64(storeKey string, option string, optArg string) error {
 	_, e := strconv.ParseUint(optArg, 0, 64)
 	if e != nil {
-		return errors.OptionArgIsInvalid{
+		return OptionArgIsInvalid{
 			StoreKey: storeKey, Option: option, OptArg: optArg, TypeKind: reflect.Uint64, Cause: e}
 	}
 	return nil
@@ -106,7 +102,7 @@ func validateUint64(storeKey string, option string, optArg string) error {
 func validateFloat32(storeKey string, option string, optArg string) error {
 	_, e := strconv.ParseFloat(optArg, 32)
 	if e != nil {
-		return errors.OptionArgIsInvalid{
+		return OptionArgIsInvalid{
 			StoreKey: storeKey, Option: option, OptArg: optArg, TypeKind: reflect.Float32, Cause: e}
 	}
 	return nil
@@ -115,7 +111,7 @@ func validateFloat32(storeKey string, option string, optArg string) error {
 func validateFloat64(storeKey string, option string, optArg string) error {
 	_, e := strconv.ParseFloat(optArg, 64)
 	if e != nil {
-		return errors.OptionArgIsInvalid{
+		return OptionArgIsInvalid{
 			StoreKey: storeKey, Option: option, OptArg: optArg, TypeKind: reflect.Float64, Cause: e}
 	}
 	return nil

--- a/validators_test.go
+++ b/validators_test.go
@@ -1,128 +1,128 @@
-package validators_test
+package cliargs_test
 
 import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/sttk/cliargs/validators"
+	"github.com/sttk/cliargs"
 )
 
 func TestValidateInt_ok(t *testing.T) {
-	err := validators.ValidateInt("FooBar", "foo-bar", "123")
+	err := cliargs.ValidateInt("FooBar", "foo-bar", "123")
 	assert.Nil(t, err)
 }
 
 func TestValidateInt_error(t *testing.T) {
-	err := validators.ValidateInt("FooBar", "foo-bar", "xx")
+	err := cliargs.ValidateInt("FooBar", "foo-bar", "xx")
 	assert.Equal(t, err.Error(), "OptionArgIsInvalid{StoreKey:FooBar,Option:foo-bar,OptArg:xx,TypeKind:int,Cause:strconv.ParseInt: parsing \"xx\": invalid syntax}")
 }
 
 func TestValidateInt8_ok(t *testing.T) {
-	err := validators.ValidateInt8("FooBar", "foo-bar", "12")
+	err := cliargs.ValidateInt8("FooBar", "foo-bar", "12")
 	assert.Nil(t, err)
 }
 
 func TestValidateInt8_error(t *testing.T) {
-	err := validators.ValidateInt8("FooBar", "foo-bar", "xx")
+	err := cliargs.ValidateInt8("FooBar", "foo-bar", "xx")
 	assert.Equal(t, err.Error(), "OptionArgIsInvalid{StoreKey:FooBar,Option:foo-bar,OptArg:xx,TypeKind:int8,Cause:strconv.ParseInt: parsing \"xx\": invalid syntax}")
 }
 
 func TestValidateInt16_ok(t *testing.T) {
-	err := validators.ValidateInt16("FooBar", "foo-bar", "123")
+	err := cliargs.ValidateInt16("FooBar", "foo-bar", "123")
 	assert.Nil(t, err)
 }
 
 func TestValidateInt16_error(t *testing.T) {
-	err := validators.ValidateInt16("FooBar", "foo-bar", "xx")
+	err := cliargs.ValidateInt16("FooBar", "foo-bar", "xx")
 	assert.Equal(t, err.Error(), "OptionArgIsInvalid{StoreKey:FooBar,Option:foo-bar,OptArg:xx,TypeKind:int16,Cause:strconv.ParseInt: parsing \"xx\": invalid syntax}")
 }
 
 func TestValidateInt32_ok(t *testing.T) {
-	err := validators.ValidateInt32("FooBar", "foo-bar", "123")
+	err := cliargs.ValidateInt32("FooBar", "foo-bar", "123")
 	assert.Nil(t, err)
 }
 
 func TestValidateInt32_error(t *testing.T) {
-	err := validators.ValidateInt32("FooBar", "foo-bar", "xx")
+	err := cliargs.ValidateInt32("FooBar", "foo-bar", "xx")
 	assert.Equal(t, err.Error(), "OptionArgIsInvalid{StoreKey:FooBar,Option:foo-bar,OptArg:xx,TypeKind:int32,Cause:strconv.ParseInt: parsing \"xx\": invalid syntax}")
 }
 
 func TestValidateInt64_ok(t *testing.T) {
-	err := validators.ValidateInt64("FooBar", "foo-bar", "123")
+	err := cliargs.ValidateInt64("FooBar", "foo-bar", "123")
 	assert.Nil(t, err)
 }
 
 func TestValidateInt64_error(t *testing.T) {
-	err := validators.ValidateInt64("FooBar", "foo-bar", "xx")
+	err := cliargs.ValidateInt64("FooBar", "foo-bar", "xx")
 	assert.Equal(t, err.Error(), "OptionArgIsInvalid{StoreKey:FooBar,Option:foo-bar,OptArg:xx,TypeKind:int64,Cause:strconv.ParseInt: parsing \"xx\": invalid syntax}")
 }
 
 func TestValidateUint_ok(t *testing.T) {
-	err := validators.ValidateUint("FooBar", "foo-bar", "123")
+	err := cliargs.ValidateUint("FooBar", "foo-bar", "123")
 	assert.Nil(t, err)
 }
 
 func TestValidateUint_error(t *testing.T) {
-	err := validators.ValidateUint("FooBar", "foo-bar", "xx")
+	err := cliargs.ValidateUint("FooBar", "foo-bar", "xx")
 	assert.Equal(t, err.Error(), "OptionArgIsInvalid{StoreKey:FooBar,Option:foo-bar,OptArg:xx,TypeKind:uint,Cause:strconv.ParseUint: parsing \"xx\": invalid syntax}")
 }
 
 func TestValidateUint8_ok(t *testing.T) {
-	err := validators.ValidateUint8("FooBar", "foo-bar", "12")
+	err := cliargs.ValidateUint8("FooBar", "foo-bar", "12")
 	assert.Nil(t, err)
 }
 
 func TestValidateUint8_error(t *testing.T) {
-	err := validators.ValidateUint8("FooBar", "foo-bar", "xx")
+	err := cliargs.ValidateUint8("FooBar", "foo-bar", "xx")
 	assert.Equal(t, err.Error(), "OptionArgIsInvalid{StoreKey:FooBar,Option:foo-bar,OptArg:xx,TypeKind:uint8,Cause:strconv.ParseUint: parsing \"xx\": invalid syntax}")
 }
 
 func TestValidateUint16_ok(t *testing.T) {
-	err := validators.ValidateUint16("FooBar", "foo-bar", "123")
+	err := cliargs.ValidateUint16("FooBar", "foo-bar", "123")
 	assert.Nil(t, err)
 }
 
 func TestValidateUint16_error(t *testing.T) {
-	err := validators.ValidateUint16("FooBar", "foo-bar", "xx")
+	err := cliargs.ValidateUint16("FooBar", "foo-bar", "xx")
 	assert.Equal(t, err.Error(), "OptionArgIsInvalid{StoreKey:FooBar,Option:foo-bar,OptArg:xx,TypeKind:uint16,Cause:strconv.ParseUint: parsing \"xx\": invalid syntax}")
 }
 
 func TestValidateUint32_ok(t *testing.T) {
-	err := validators.ValidateUint32("FooBar", "foo-bar", "123")
+	err := cliargs.ValidateUint32("FooBar", "foo-bar", "123")
 	assert.Nil(t, err)
 }
 
 func TestValidateUint32_error(t *testing.T) {
-	err := validators.ValidateUint32("FooBar", "foo-bar", "xx")
+	err := cliargs.ValidateUint32("FooBar", "foo-bar", "xx")
 	assert.Equal(t, err.Error(), "OptionArgIsInvalid{StoreKey:FooBar,Option:foo-bar,OptArg:xx,TypeKind:uint32,Cause:strconv.ParseUint: parsing \"xx\": invalid syntax}")
 }
 
 func TestValidateUint64_ok(t *testing.T) {
-	err := validators.ValidateUint64("FooBar", "foo-bar", "123")
+	err := cliargs.ValidateUint64("FooBar", "foo-bar", "123")
 	assert.Nil(t, err)
 }
 
 func TestValidateUint64_error(t *testing.T) {
-	err := validators.ValidateUint64("FooBar", "foo-bar", "xx")
+	err := cliargs.ValidateUint64("FooBar", "foo-bar", "xx")
 	assert.Equal(t, err.Error(), "OptionArgIsInvalid{StoreKey:FooBar,Option:foo-bar,OptArg:xx,TypeKind:uint64,Cause:strconv.ParseUint: parsing \"xx\": invalid syntax}")
 }
 
 func TestValidateFloat32_ok(t *testing.T) {
-	err := validators.ValidateFloat32("FooBar", "foo-bar", "123")
+	err := cliargs.ValidateFloat32("FooBar", "foo-bar", "123")
 	assert.Nil(t, err)
 }
 
 func TestValidateFloat32_error(t *testing.T) {
-	err := validators.ValidateFloat32("FooBar", "foo-bar", "xx")
+	err := cliargs.ValidateFloat32("FooBar", "foo-bar", "xx")
 	assert.Equal(t, err.Error(), "OptionArgIsInvalid{StoreKey:FooBar,Option:foo-bar,OptArg:xx,TypeKind:float32,Cause:strconv.ParseFloat: parsing \"xx\": invalid syntax}")
 }
 
 func TestValidateFloat64_ok(t *testing.T) {
-	err := validators.ValidateFloat64("FooBar", "foo-bar", "123")
+	err := cliargs.ValidateFloat64("FooBar", "foo-bar", "123")
 	assert.Nil(t, err)
 }
 
 func TestValidateFloat64_error(t *testing.T) {
-	err := validators.ValidateFloat64("FooBar", "foo-bar", "xx")
+	err := cliargs.ValidateFloat64("FooBar", "foo-bar", "xx")
 	assert.Equal(t, err.Error(), "OptionArgIsInvalid{StoreKey:FooBar,Option:foo-bar,OptArg:xx,TypeKind:float64,Cause:strconv.ParseFloat: parsing \"xx\": invalid syntax}")
 }


### PR DESCRIPTION
This PR removes sub packages and moves program element in them to the root package.

The reason for this modification is as follows:
- The sub package name `errors` conflicts the one of go standard package.
- Not only the root package but also its sub-packages must be imported.